### PR TITLE
Use queryExecute instead of Query() for query of query

### DIFF
--- a/models/Query/Grammars/MSSQLGrammar.cfc
+++ b/models/Query/Grammars/MSSQLGrammar.cfc
@@ -5,7 +5,7 @@ component extends="qb.models.Query.Grammars.Grammar" {
         "groups", "havings", "orders", "offsetValue", "limitValue"
     ];
 
-    private string function compileOffsetValue( required Builder query, offsetValue ) {
+    private string function compileOffsetValue( required qb.models.Query.Builder query, offsetValue ) {
         if ( isNull( query.getOffsetValue() ) && isNull( query.getLimitValue() ) ) {
             return "";
         }
@@ -17,7 +17,7 @@ component extends="qb.models.Query.Grammars.Grammar" {
         return "OFFSET #offsetValue# ROWS";
     }
 
-    private string function compileLimitValue( required Builder query, limitValue ) {
+    private string function compileLimitValue( required qb.models.Query.Builder query, limitValue ) {
         if ( isNull( arguments.limitValue ) ) {
             return "";
         }

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -1,5 +1,5 @@
 component displayname="QueryUtils" {
-    
+
     public struct function extractBinding( required any value ) {
         var binding = isStruct( value ) ? value : { value = normalizeSqlValue( value ) };
 
@@ -55,9 +55,9 @@ component displayname="QueryUtils" {
     *
     * @param theQuery     The query to manipulate. (Required)
     * @param columnsToRemove      A list of columns to remove. (Required)
-    * @return Returns a query. 
-    * @author Giampaolo Bellavite (giampaolo@bellavite.com) 
-    * @version 1, April 14, 2005 
+    * @return Returns a query.
+    * @author Giampaolo Bellavite (giampaolo@bellavite.com)
+    * @version 1, April 14, 2005
     */
     public query function queryRemoveColumns(
         required query q,
@@ -70,11 +70,11 @@ component displayname="QueryUtils" {
                 columnList = ListDeleteAt( columnList, columnPosition );
             }
         }
-        var newQuery = new Query();
-        newQuery.setDBType( "query" );
-        newQuery.setAttributes( qbOriginalQuery = arguments.q );
-        newQuery.setSQL( "SELECT #columnList# FROM qbOriginalQuery" );
-        return newQuery.execute().getResult();
+        return queryExecute(
+          "SELECT #columnList# FROM arguments.q",
+          {},
+          {dbtype="query"}
+        );
     }
 
     private string function normalizeSqlValue( required any value ) {
@@ -89,7 +89,7 @@ component displayname="QueryUtils" {
         if ( isStruct( value ) || isArray( value ) ) {
             return false;
         }
-        
+
         var listAsArray = listToArray( arguments.value );
         return arrayLen( listAsArray ) > 1;
     }

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -71,9 +71,9 @@ component displayname="QueryUtils" {
             }
         }
         return queryExecute(
-          "SELECT #columnList# FROM arguments.q",
-          {},
-          {dbtype="query"}
+            "SELECT #columnList# FROM arguments.q",
+            {},
+            { dbtype = "query" }
         );
     }
 

--- a/tests/specs/Query/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/QueryUtilsSpec.cfc
@@ -89,5 +89,21 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
                 expect( result ).toBe( data );
             } );
         } );
+
+        describe( "queryRemoveColumns()", function() {
+            it( "returns the query with specified columns removed", function() {
+                var data = [
+                    { id = 1, name = "foo", age = 24 },
+                    { id = 2, name = "bar", age = 32 },
+                    { id = 3, name = "baz", age = 41 }
+                ];
+                var q = queryNew( "id,name,age", "integer,varchar,integer", data );
+                var result = utils.queryRemoveColumns( q, "age,name" );
+
+                expect( result ).toBeQuery();
+                expect( result.recordCount ).toBe( 3 );
+                expect( result.columnList ).toBe( "id" );
+            } );
+        } );
     }
 }


### PR DESCRIPTION
Changes:

- Use queryExecute instead of Query() for query of query as it's buggy in ACF. 
- Used dotted path for argument type to get test suite to run on ACF11

Tested against Lucee 4.5 and ACF 11