### PR TITLE
queryRemoveColumns() fix for OracleGrammer

### DIFF
--- a/models/Query/Grammars/OracleGrammar.cfc
+++ b/models/Query/Grammars/OracleGrammar.cfc
@@ -4,7 +4,7 @@ component extends="qb.models.Query.Grammars.Grammar" {
 
     public any function runQuery( sql, bindings, options ) {
         var result = super.runQuery( argumentCollection = arguments );
-        if ( ! isNull( result ) ) {
+        if ( result.recordCount > 0 ) {
             return utils.queryRemoveColumns( result, "QB_RN" );
         }
         return;

--- a/tests/specs/Query/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/QueryUtilsSpec.cfc
@@ -104,6 +104,17 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
                 expect( result.recordCount ).toBe( 3 );
                 expect( result.columnList ).toBe( "id" );
             } );
+
+            it( "returns the query with specified columns removed when no rows exist in query", function() {
+                var data = [
+                ];
+                var q = queryNew( "id,name,age", "integer,varchar,integer", data );
+                var result = utils.queryRemoveColumns( q, "age,name" );
+
+                expect( result ).toBeQuery();
+                expect( result.recordCount ).toBe( 0 );
+                expect( result.columnList ).toBe( "id" );
+            } );
         } );
     }
 }


### PR DESCRIPTION
Add a check to only try to remove the QB_RN column when records actually exist in the query. Chose to add the check in the OracleGrammar section so that queryRemoveColumns can still remove columns even if recordCount is 0. Not sure if that is needed, but that was the reasoning.