### PR TITLE
First stab at implementing the various requirements for issue #8 

### DIFF
--- a/models/Query/Builder.cfc
+++ b/models/Query/Builder.cfc
@@ -146,8 +146,6 @@ component displayname="Builder" accessors="true" {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
 
-        
-
         setReturnFormat( arguments.returnFormat );
 
         setDefaultValues();

--- a/models/Query/Builder.cfc
+++ b/models/Query/Builder.cfc
@@ -125,6 +125,11 @@ component displayname="Builder" accessors="true" {
     };
 
     /**
+    * Array holding the valid directions that a column can be sorted by in an order by clause.
+    */
+    variables.directions = [ "asc", "desc" ];
+
+    /**
     * Creates an empty query builder.
     *
     * @grammar The grammar to use when compiling queries. Default: qb.models.Query.Grammars.Grammar
@@ -140,6 +145,8 @@ component displayname="Builder" accessors="true" {
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
+
+        
 
         setReturnFormat( arguments.returnFormat );
 
@@ -1114,7 +1121,6 @@ component displayname="Builder" accessors="true" {
     * @return qb.models.Query.Builder
     */
     public Builder function orderBy( required any column, string direction = "asc" ) {
-        var validDirections = [ "asc", "desc" ];
 
         if ( getUtils().isExpression( column ) ) {
             variables.orders.append( {
@@ -1134,32 +1140,12 @@ component displayname="Builder" accessors="true" {
                         column = col
                     } );
                 }
-                // ex: "favorite_color|desc,height|asc,weight|desc"
-                else if ( isSimpleValue( col ) && listLen( col ) > 1 ) {
-                    //convert list to array for easier looping and access to vals
-                    var arCols = listToArray( col );
-
-                    for ( var c in arCols ) {
-                        var colName = listFirst( c, "|" );
-                        
-                        if ( listLen( c, "|" ) == 2 ) {
-                            var dir = ( arrayFindNoCase( validDirections, listLast( c, "|" ) ) ) ? listLast( c, "|" ) : direction;
-                        } else {
-                            var dir = direction;
-                        }
-
-                        variables.orders.append( {
-                            direction = dir,
-                            column = colName
-                        } );
-                    }
-                }
                 // ex: "age|desc" || "last_name"
                 else if ( isSimpleValue( col ) ) {
                     var colName = listFirst( col, "|" );
                     // ex: "age|desc"
                     if ( listLen( col, "|" ) == 2 ) {
-                        var dir = ( arrayFindNoCase( validDirections, listLast( col, "|" ) ) ) ? listLast( col, "|" ) : direction;
+                        var dir = ( arrayFindNoCase( variables.directions, listLast( col, "|" ) ) ) ? listLast( col, "|" ) : direction;
                     } else {
                         var dir = direction;
                     }
@@ -1176,7 +1162,7 @@ component displayname="Builder" accessors="true" {
                     if ( getUtils().isExpression( col.column ) ) {
                         var dir = "raw";
                     } else {
-                        var dir = ( structKeyExists( col, "direction") && arrayFindNoCase( validDirections, col.direction ) ) ? col.direction : direction;
+                        var dir = ( structKeyExists( col, "direction") && arrayFindNoCase( variables.directions, col.direction ) ) ? col.direction : direction;
                     }
                     variables.orders.append({
                         direction = dir,
@@ -1187,7 +1173,7 @@ component displayname="Builder" accessors="true" {
                 else if ( isArray( col ) ) {
                     //assume position 1 is the column name and position 2 if it exists and is a valid direction ( asc | desc ) use it.
                     variables.orders.append({
-                        direction = ( arrayLen( col ) == 2 && arrayFindNoCase( validDirections, col[2] ) ) ? col[2] : direction,
+                        direction = ( arrayLen( col ) == 2 && arrayFindNoCase( variables.directions, col[2] ) ) ? col[2] : direction,
                         column = col[1]
                     });
                 }
@@ -1204,7 +1190,7 @@ component displayname="Builder" accessors="true" {
                 var colName = listFirst( col, "|" );
                 
                 if ( listLen( col, "|" ) == 2 ) {
-                    var dir = ( arrayFindNoCase( validDirections, listLast( col, "|" ) ) ) ? listLast( col, "|" ) : direction;
+                    var dir = ( arrayFindNoCase( variables.directions, listLast( col, "|" ) ) ) ? listLast( col, "|" ) : direction;
                 } else {
                     var dir = direction;
                 }

--- a/tests/specs/Query/Builder+GrammarSpec.cfc
+++ b/tests/specs/Query/Builder+GrammarSpec.cfc
@@ -867,14 +867,14 @@ component extends="testbox.system.BaseSpec" {
                                     .orderBy( [
                                         "last_name",
                                         "age|desc"
-                                    ])
+                                    ] )
                                     .orderBy( "favorite_color", "desc" )
                                     .orderBy( column = [ { column = "height" }, { column = "weight", direction = "asc" } ], direction = "desc" )
                                     .orderBy( column = "eye_color", direction = "desc" )
                                     .orderBy( [
                                         { column = "is_athletic", direction = "desc", extraKey = "ignored" },
                                         builder.raw( "DATE(created_at)" )
-                                    ])
+                                    ] )
                                     .orderBy( builder.raw( "DATE(modified_at)" ) );
 
                                 expect( builder.toSql() ).toBeWithCase(


### PR DESCRIPTION
Adjusted the order by function to accept an array or list as the column argument's value. 

The array can accept a variety of formats for the values in the array and the value formats can be intermingled if desired. 

All scenarios will inherit either the default direction or the supplied value for the direction argument.

Hopefully this is getting pretty close to meeting all of the edge scenarios that people would look to utilize. Keeps those "list" people happy, but also allows for a a complex order by to be created with one call instead of having to chain many calls to build up the where clause. 

Likely need a few more tests to make sure that "additional" `orderBy()` calls are properly appended to the overall order by clause when the method is chained.