### PR TITLE
update MSSQL for DEFAULT constraint

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -796,7 +796,7 @@ component displayname="Grammar" accessors="true" {
             generateNullConstraint( column ),
             generateUniqueConstraint( column, blueprint ),
             generateAutoIncrement( column, blueprint ),
-            generateDefault( column ),
+            generateDefault( column, blueprint ),
             generateComment( column, blueprint )
         ], function( item ) {
             return item != "";

--- a/models/Grammars/MSSQLGrammar.cfc
+++ b/models/Grammars/MSSQLGrammar.cfc
@@ -139,6 +139,10 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return column.getAutoIncrement() ? "IDENTITY" : "";
     }
 
+    function generateDefault( column, blueprint ) {
+        return column.getDefault() != "" ? "CONSTRAINT DF_#blueprint.getTable()#_#column.getName()# DEFAULT #column.getDefault()#" : "";
+    }
+
     function generateComment( column ) {
         return "";
     }


### PR DESCRIPTION
Eric, 
I had a look at adding the default constraint as an index. But this made everything way too complicated, since Oracle, MySQL and Postgres don't support constraints for DEFAULT. So if we woud do it this way we had to generate empty constraints, filter them away and add a new property to TableIndex so you could save the value of the DEFAULT constraint in an index instead of in the column properties
Now I only changed the syntax in MSSQL for generating a constraint, so it always has a predictable name.
Default constraint name is DF__tablename___columname_ . This way it is easy to remove a default constraint before removing the column.
We should just mention this in the  docs, but for MSSQL it is fine now, at least according to me :-)