### PR TITLE
Fixes JoinClause.newQuery() datatype

### DIFF
--- a/models/Query/JoinClause.cfc
+++ b/models/Query/JoinClause.cfc
@@ -108,7 +108,7 @@ component
     *
     * @return qb.models.Builder.JoinClause
     */
-    public Builder function newQuery() {
+    public QueryBuilder function newQuery() {
         return new qb.models.Query.JoinClause(
             parentQuery = getParentQuery(),
             type = getType(),

--- a/tests/specs/Query/Abstract/JoinClauseSpec.cfc
+++ b/tests/specs/Query/Abstract/JoinClauseSpec.cfc
@@ -139,6 +139,27 @@ component extends="testbox.system.BaseSpec" {
                         expect( binding.cfsqltype ).toBe( "cf_sql_varchar" );
                     } );
                 } );
+
+                describe( "newQuery()", function() {
+                    it( "creates a new JoinClause instance", function() {
+                        expect( join.newQuery() ).toBeInstanceOf( "qb.models.Query.JoinClause" );
+                    } );
+
+                    it( "binds the parent query", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getParentQuery() ).toBe( join.getParentQuery() );
+                    } );
+
+                    it( "binds the type", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getType() ).toBe( join.getType() );
+                    } );
+
+                    it( "binds the table", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getTable() ).toBe( join.getTable() );
+                    } );
+                } );
             } );
         } );
     }


### PR DESCRIPTION
This fixes #46 where the wrong datatype was being returned for the newQuery() method. I also added unit test coverage.