### PR TITLE
Issue 3 union support

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -532,8 +532,10 @@ component displayname="Grammar" accessors="true" {
         }
         
         var sql = arguments.unions.map(function (union){
-           var sql = arguments.union.query.toSQL();
-
+            /*
+             * No queries being unioned to the origin query can contain an ORDER BY clause, only the outer-most
+             * QueryBuilder instance can actually have a defined orderBy().
+             */
             if( arguments.union.query.getOrders().len() ){
                 throw(
                     type = "OrderByNotAllowed",
@@ -541,6 +543,8 @@ component displayname="Grammar" accessors="true" {
                     detail = "A QueryBuilder instance used in a UNION statement is cannot have any ORDER BY clause, as this is not allowed by SQL. Only the outer most query is allowed to specify an ORDER BY clause which will be used on the unioned queries."
                 );
             }
+
+           var sql = arguments.union.query.toSQL();
 
             return "UNION " & (arguments.union.all ? "ALL " : "") & sql;
         });

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -31,7 +31,7 @@ component displayname="Grammar" accessors="true" {
     */
     variables.selectComponents = [
         "aggregate", "columns", "from", "joins", "wheres",
-        "groups", "havings", "orders", "limitValue", "offsetValue"
+        "groups", "havings", "unions", "orders", "limitValue", "offsetValue"
     ];
 
     /**
@@ -515,6 +515,37 @@ component displayname="Grammar" accessors="true" {
         var placeholder = isInstanceOf( having.value, "qb.models.Query.Expression" ) ?
             having.value.getSQL() : "?";
         return trim( "#having.combinator# #wrapColumn( having.column )# #having.operator# #placeholder#" );
+    }
+
+
+    /**
+    * Compiles the UNION portion of a sql statement.
+    *
+    * @query The Builder instance.
+    * @orders The union clauses.
+    *
+    * @return string
+    */
+    private string function compileUnions( required QueryBuilder query, required array unions ) {
+        if ( arguments.unions.isEmpty() ) {
+            return "";
+        }
+        
+        var sql = arguments.unions.map(function (union){
+           var sql = arguments.union.query.toSQL();
+
+            if( arguments.union.query.getOrders().len() ){
+                throw(
+                    type = "OrderByNotAllowed",
+                    message = "The ORDER BY clause is not allowed in a UNION statement.",
+                    detail = "A QueryBuilder instance used in a UNION statement is cannot have any ORDER BY clause, as this is not allowed by SQL. Only the outer most query is allowed to specify an ORDER BY clause which will be used on the unioned queries."
+                );
+            }
+
+            return "UNION " & (arguments.union.all ? "ALL " : "") & sql;
+        });
+
+        return trim( arrayToList(sql, ' ') );
     }
 
     /**

--- a/models/Grammars/MSSQLGrammar.cfc
+++ b/models/Grammars/MSSQLGrammar.cfc
@@ -5,7 +5,7 @@ component extends="qb.models.Grammars.BaseGrammar" {
     */
     variables.selectComponents = [
         "aggregate", "columns", "from", "joins", "wheres",
-        "groups", "havings", "orders", "offsetValue", "limitValue"
+        "groups", "havings", "unions", "orders", "offsetValue", "limitValue"
     ];
 
     /**

--- a/models/Query/JoinClause.cfc
+++ b/models/Query/JoinClause.cfc
@@ -108,7 +108,7 @@ component
     *
     * @return qb.models.Builder.JoinClause
     */
-    public Builder function newQuery() {
+    public QueryBuilder function newQuery() {
         return new qb.models.Query.JoinClause(
             parentQuery = getParentQuery(),
             type = getType(),

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -78,6 +78,12 @@ component displayname="QueryBuilder" accessors="true" {
     property name="havings" type="array";
 
     /**
+    * An array of UNION statements.
+    * @default []
+    */
+    property name="unions" type="array";
+
+    /**
     * An array of ORDER BY statements.
     * @default []
     */
@@ -121,6 +127,7 @@ component displayname="QueryBuilder" accessors="true" {
         "select" = [],
         "join" = [],
         "where" = [],
+        "union" = [],
         "insert" = [],
         "update" = []
     };
@@ -168,6 +175,7 @@ component displayname="QueryBuilder" accessors="true" {
         variables.groups = [];
         variables.havings = [];
         variables.orders = [];
+        variables.unions = [];
     }
 
     /**********************************************************************************************\
@@ -1259,6 +1267,47 @@ component displayname="QueryBuilder" accessors="true" {
         return this;
     }
 
+    /*******************************************************************************\
+    |         UNION functions                                                       |
+    \*******************************************************************************/
+
+    /**
+    * Add a UNION statement to the SQL.
+    *
+    * @input    Either a QueryBuilder instance or a closure to define the derived query.
+    * @all Determines if UNION statement should be a "UNION ALL".  Passing this as an argument is discouraged.  Use the dedicated `unionAll` where possible.
+    * @return qb.models.Query.QueryBuilder
+    */
+    public QueryBuilder function union(required any input, boolean all=false) {
+        var qb = arguments.input;
+
+        // since we have a callback, we generate a new query object and pass it into the callback
+        if( isClosure(qb) ){
+            var subquery = newQuery();
+            qb(subquery);
+            // replace the original query builder with the results of the sub-query
+            qb = subquery;
+        }
+
+        // track the union statement
+        variables.unions.append({query=qb, all=arguments.all});
+
+        // track the bindings for the CTE
+        addBindings( qb.getBindings(), "union" );
+
+        return this;
+    }
+
+    /**
+    * Add a UNION ALL statement to the SQL.
+    *
+    * @input Either a QueryBuilder instance or a closure to define the derived query.
+    * @return qb.models.Query.QueryBuilder
+    */
+    public QueryBuilder function unionAll(required any input) {
+        return union(arguments.input, true);
+    }
+
     /**
     * Sets the limit value for the query.
     *
@@ -1509,7 +1558,7 @@ component displayname="QueryBuilder" accessors="true" {
     * @return array of bindings
     */
     public array function getBindings() {
-        var bindingOrder = [ "update", "insert", "select", "join", "where" ];
+        var bindingOrder = [ "update", "insert", "select", "join", "where", "union" ];
 
         var flatBindings = [];
         for ( var key in bindingOrder ) {
@@ -1539,7 +1588,7 @@ component displayname="QueryBuilder" accessors="true" {
         arguments.only = isArray( arguments.only ) ? arguments.only : [ arguments.only ];
         arguments.except = isArray( arguments.except ) ? arguments.except : [ arguments.except ];
         if ( arguments.only.isEmpty() ) {
-            arguments.only = [ "select", "join", "where", "insert", "update" ];
+            arguments.only = [ "select", "join", "where", "union", "insert", "update" ];
         }
 
         for ( var bindingType in arguments.only ) {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -778,6 +778,153 @@ component extends="testbox.system.BaseSpec" {
                     } );
                 } );
 
+                describe( "unions", function() {
+                    it( "can union multiple statements using a closure", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .select("name")
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .union(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 2 )
+                                    ;
+                                })
+                                .union(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 3 )
+                                    ;
+                                })
+                            ;
+                        }, union() );
+                    } );
+
+                    it( "can union multiple statements using a QueryBuilder instance", function() {
+                        testCase( function( builder ) {
+                            var union2 = getBuilder().select("name").from("users").where( "id", 2 );
+                            var union3 = getBuilder().select("name").from("users").where( "id", 3 );
+                            
+                            builder
+                                .select("name")
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .union(union2)
+                                .union(union3)
+                            ;
+                        }, union() );
+                    } );
+
+                    it( "union can contain order by on main query only", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .select("name")
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .union(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 2 )
+                                    ;
+                                })
+                                .union(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 3 )
+                                    ;
+                                })
+                                .orderBy("name")
+                            ;
+                        }, unionOrderBy() );
+                    } );
+
+                    it( "union query cannot contain orderBy", function() {
+                        var builder = getBuilder();
+
+                        builder
+                            .select("name")
+                            .from( "users" )
+                            .where( "id", 1 )
+                            .union(function (q){
+                                q
+                                    .select("name")
+                                    .from("users")
+                                    .where( "id", 2 )
+                                    .orderBy("name")
+                                ;
+                            })
+                            .union(function (q){
+                                q
+                                    .select("name")
+                                    .from("users")
+                                    .where( "id", 3 )
+                                ;
+                            })
+                            .orderBy("name")
+                        ;
+
+
+                        try {
+                            var statements = builder.toSql();
+                        }
+                        catch ( any e ) {
+                            // Darn ACF nests the exception message. 😠
+                            if ( e.message == "An exception occurred while calling the function map." ) {
+                                expect( e.detail ).toBe( "The ORDER BY clause is not allowed in a UNION statement." );
+                            }
+                            else {
+                                expect( e.message ).toBe( "The ORDER BY clause is not allowed in a UNION statement." );
+                            }
+                            return;
+                        }
+                        fail( "Should have caught an exception, but didn't." );
+                    } );
+
+                    it( "can union all multiple statements using a closure", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .select("name")
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .unionAll(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 2 )
+                                    ;
+                                })
+                                .unionAll(function (q){
+                                    q
+                                        .select("name")
+                                        .from("users")
+                                        .where( "id", 3 )
+                                    ;
+                                })
+                            ;
+                        }, unionAll() );
+                    } );
+
+                    it( "can union all multiple statements using a QueryBuilder instance", function() {
+                        testCase( function( builder ) {
+                            var union2 = getBuilder().select("name").from("users").where( "id", 2 );
+                            var union3 = getBuilder().select("name").from("users").where( "id", 3 );
+                            
+                            builder
+                                .select("name")
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .unionAll(union2)
+                                .unionAll(union3)
+                            ;
+                        }, unionAll() );
+                    } );
+                } );
+
                 describe( "limits", function() {
                     it( "can limit the record set returned", function() {
                         testCase( function( builder ) {

--- a/tests/specs/Query/Abstract/JoinClauseSpec.cfc
+++ b/tests/specs/Query/Abstract/JoinClauseSpec.cfc
@@ -139,6 +139,27 @@ component extends="testbox.system.BaseSpec" {
                         expect( binding.cfsqltype ).toBe( "cf_sql_varchar" );
                     } );
                 } );
+
+                describe( "newQuery()", function() {
+                    it( "creates a new JoinClause instance", function() {
+                        expect( join.newQuery() ).toBeInstanceOf( "qb.models.Query.JoinClause" );
+                    } );
+
+                    it( "binds the parent query", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getParentQuery() ).toBe( join.getParentQuery() );
+                    } );
+
+                    it( "binds the type", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getType() ).toBe( join.getType() );
+                    } );
+
+                    it( "binds the table", function() {
+                        var newJoin = join.newQuery();
+                        expect( newJoin.getTable() ).toBe( join.getTable() );
+                    } );
+                } );
             } );
         } );
     }

--- a/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
@@ -429,6 +429,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM [users] ORDER BY [last_name] ASC, [age] DESC, [favorite_color] ASC";
     }
 
+    function union() {
+        return {
+            sql = "SELECT [name] FROM [users] WHERE [id] = ? UNION SELECT [name] FROM [users] WHERE [id] = ? UNION SELECT [name] FROM [users] WHERE [id] = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionOrderBy() {
+        return {
+            sql = "SELECT [name] FROM [users] WHERE [id] = ? UNION SELECT [name] FROM [users] WHERE [id] = ? UNION SELECT [name] FROM [users] WHERE [id] = ? ORDER BY [name] ASC",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionAll() {
+        return {
+            sql = "SELECT [name] FROM [users] WHERE [id] = ? UNION ALL SELECT [name] FROM [users] WHERE [id] = ? UNION ALL SELECT [name] FROM [users] WHERE [id] = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
     function limit() {
         return "SELECT TOP (3) * FROM [users]";
     }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -429,6 +429,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM `users` ORDER BY `last_name` ASC, `age` DESC, `favorite_color` ASC";
     }
 
+    function union() {
+        return {
+            sql = "SELECT `name` FROM `users` WHERE `id` = ? UNION SELECT `name` FROM `users` WHERE `id` = ? UNION SELECT `name` FROM `users` WHERE `id` = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionOrderBy() {
+        return {
+            sql = "SELECT `name` FROM `users` WHERE `id` = ? UNION SELECT `name` FROM `users` WHERE `id` = ? UNION SELECT `name` FROM `users` WHERE `id` = ? ORDER BY `name` ASC",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionAll() {
+        return {
+            sql = "SELECT `name` FROM `users` WHERE `id` = ? UNION ALL SELECT `name` FROM `users` WHERE `id` = ? UNION ALL SELECT `name` FROM `users` WHERE `id` = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM `users` LIMIT 3";
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -429,6 +429,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM ""USERS"" ORDER BY ""LAST_NAME"" ASC, ""AGE"" DESC, ""FAVORITE_COLOR"" ASC";
     }
 
+    function union() {
+        return {
+            sql = "SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionOrderBy() {
+        return {
+            sql = "SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? ORDER BY ""NAME"" ASC",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionAll() {
+        return {
+            sql = "SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION ALL SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION ALL SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM (SELECT results.*, ROWNUM AS ""QB_RN"" FROM (SELECT * FROM ""USERS"") results ) WHERE ""QB_RN"" <= 3";
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -429,6 +429,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" DESC, ""favorite_color"" ASC";
     }
 
+    function union() {
+        return {
+            sql = "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionOrderBy() {
+        return {
+            sql = "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? ORDER BY ""name"" ASC",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
+    function unionAll() {
+        return {
+            sql = "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION ALL SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION ALL SELECT ""name"" FROM ""users"" WHERE ""id"" = ?",
+            bindings = [ 1, 2, 3 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM ""users"" LIMIT 3";
     }


### PR DESCRIPTION
Fixes issue #3 by adding support for UNION and UNION ALL. You can either feed in another QB to the union() and unionAll() methods or use a closure to define the query.