### PR TITLE
Qb 12 unicode text functions

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1157,6 +1157,10 @@ component displayname="Grammar" accessors="true" {
         return "TEXT";
     }
 
+    function typeUnicodeLongText( column ) {
+        return "TEXT";
+    }
+
     function typeMediumInteger( column ) {
         return arrayToList( arrayFilter( [
             "MEDIUMINT",
@@ -1167,6 +1171,10 @@ component displayname="Grammar" accessors="true" {
     }
 
     function typeMediumText( column ) {
+        return "TEXT";
+    }
+
+    function typeUnicodeMediumText( column ) {
         return "TEXT";
     }
 
@@ -1183,8 +1191,16 @@ component displayname="Grammar" accessors="true" {
         return "VARCHAR(#column.getLength()#)";
     }
 
+    function typeUnicodeString( column ) {
+        return "NVARCHAR(#column.getLength()#)";
+    }
+
     function typeText( column ) {
         return "TEXT";
+    }
+
+    function typeUnicodeText( column ) {
+         return "TEXT";
     }
 
     function typeTime( column ) {

--- a/models/Grammars/MSSQLGrammar.cfc
+++ b/models/Grammars/MSSQLGrammar.cfc
@@ -246,6 +246,10 @@ component extends="qb.models.Grammars.BaseGrammar" {
     }
 
     function typeLongText( column ) {
+        return "VARCHAR(MAX)";
+    }
+
+    function typeUnicodeLongText( column ) {
         return "NVARCHAR(MAX)";
     }
 
@@ -258,6 +262,10 @@ component extends="qb.models.Grammars.BaseGrammar" {
     }
 
     function typeMediumText( column ) {
+        return "VARCHAR(MAX)";
+    }
+
+    function typeUnicodeMediumText( column ) {
         return "NVARCHAR(MAX)";
     }
 
@@ -269,11 +277,11 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return "SMALLINT";
     }
 
-    function typeString( column ) {
-        return "NVARCHAR(#column.getLength()#)";
+    function typeText( column ) {
+        return "VARCHAR(MAX)";
     }
 
-    function typeText( column ) {
+    function typeUnicodeText( column ) {
         return "NVARCHAR(MAX)";
     }
 

--- a/models/Grammars/MSSQLGrammar.cfc
+++ b/models/Grammars/MSSQLGrammar.cfc
@@ -242,11 +242,11 @@ component extends="qb.models.Grammars.BaseGrammar" {
     }
 
     function typeJson( column ) {
-        return "NTEXT";
+        return "NVARCHAR(MAX)";
     }
 
     function typeLongText( column ) {
-        return "NTEXT";
+        return "NVARCHAR(MAX)";
     }
 
     function typeMediumInteger( column ) {
@@ -258,7 +258,7 @@ component extends="qb.models.Grammars.BaseGrammar" {
     }
 
     function typeMediumText( column ) {
-        return "NTEXT";
+        return "NVARCHAR(MAX)";
     }
 
     function typeSmallInteger( column ) {
@@ -274,7 +274,7 @@ component extends="qb.models.Grammars.BaseGrammar" {
     }
 
     function typeText( column ) {
-        return "NTEXT";
+        return "NVARCHAR(MAX)";
     }
 
     function typeTimestamp( column ) {

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -79,10 +79,6 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return super.generateDefault( column );
     }
 
-    function typeString( column ) {
-        return "NVARCHAR(#column.getLength()#)";
-    }
-
     function typeChar( column ) {
         return "NCHAR(#column.getLength()#)";
     }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -316,6 +316,10 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return "CLOB";
     }
 
+    function typeUnicodeLongText( column ) {
+        return "CLOB";
+    }
+
     function typeMediumInteger( column ) {
         var precision = isNull( column.getPrecision() ) ? 7 : column.getPrecision();
         return "NUMBER(#precision#, 0)";
@@ -334,7 +338,15 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return "VARCHAR2(#column.getLength()#)";
     }
 
+    function typeUnicodeString( column ) {
+        return "VARCHAR2(#column.getLength()#)";
+    }
+
     function typeText( column ) {
+        return "CLOB";
+    }
+
+    function typeUnicodeText( column ) {
         return "CLOB";
     }
 

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -47,7 +47,7 @@ component extends="qb.models.Grammars.BaseGrammar" {
             "ALTER COLUMN",
             wrapColumn( commandParameters.to.getName() ),
             "TYPE",
-            ucase( commandParameters.to.getType() ) & ",",
+            generateType( commandParameters.to, blueprint ) & ",",
             "ALTER COLUMN",
             wrapColumn( commandParameters.to.getName() ),
             commandParameters.to.getNullable() ? "DROP" : "SET",

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -208,6 +208,14 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return "SMALLINT";
     }
 
+    function typeUnicodeString( column ) {
+        return typeString( argumentCollection = arguments );
+    }
+
+    function typeUnicodeText( column ) {
+        return typeText( argumentCollection = arguments );
+    }
+
     function typeTinyInteger( column ) {
         if ( column.getAutoIncrement() ) {
             return "SERIAL";

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -106,6 +106,11 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
+    function unicodeLongText( name ) {
+        arguments.type = "unicodeLongText";
+        return appendColumn( argumentCollection = arguments);
+    }
+
     function mediumIncrements( name, indexName ) {
         arguments.autoIncrement = true;
         arguments.indexName = isNull( indexName ) ? "pk_#getTable()#_#name#" : arguments.indexName;
@@ -120,6 +125,11 @@ component accessors="true" {
 
     function mediumText( name ) {
         arguments.type = "mediumText";
+        return appendColumn( argumentCollection = arguments );
+    }
+
+    function unicodeMediumText( name ) {
+        arguments.type = "unicodeMediumText";
         return appendColumn( argumentCollection = arguments );
     }
 
@@ -170,8 +180,21 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
+     function unicodeString( name, length ) {
+        arguments.type = "unicodeString";
+        if ( isNull( arguments.length ) ) {
+            arguments.length = getSchemaBuilder().getDefaultStringLength();
+        }
+        return appendColumn( argumentCollection = arguments );
+    }
+
     function text( name ) {
         arguments.type = "text";
+        return appendColumn( argumentCollection = arguments );
+    }
+
+    function unicodeText( name ) {
+        arguments.type = "unicodeText";
         return appendColumn( argumentCollection = arguments );
     }
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -11,8 +11,8 @@ component extends="testbox.system.BaseSpec" {
             it( "can create a simple table", function() {
                 testCase( function( schema ) {
                     return schema.create( "users", function( table ) {
-                        table.string( "username" );
-                        table.string( "password" );
+                        table.unicodeString( "username" );
+                        table.unicodeString( "password" );
                     }, {}, false );
                 }, simpleTable() );
             } );
@@ -21,10 +21,10 @@ component extends="testbox.system.BaseSpec" {
                 testCase( function( schema ) {
                     return schema.create( "users", function( table ) {
                         table.increments( "id" );
-                        table.string( "username" );
-                        table.string( "first_name" );
-                        table.string( "last_name" );
-                        table.string( "password", 100 );
+                        table.unicodeString( "username" );
+                        table.unicodeString( "first_name" );
+                        table.unicodeString( "last_name" );
+                        table.unicodeString( "password", 100 );
                         table.unsignedInteger( "country_id" ).references( "id" ).onTable( "countries" ).onDelete( "cascade" );
                         table.timestamp( "created_date" ).setDefault( "CURRENT_TIMESTAMP" );
                         table.timestamp( "modified_date" ).setDefault( "CURRENT_TIMESTAMP" );
@@ -225,6 +225,14 @@ component extends="testbox.system.BaseSpec" {
                     }, longText() );
                 } );
 
+                it( "unicodeLongText", function() {
+                    testCase( function( schema ) {
+                        return schema.create( "posts", function( table ) {
+                            table.unicodeLongText( "body" );
+                        }, {}, false );
+                    }, unicodeLongText() );
+                } );
+
                 it( "mediumIncrements", function() {
                     testCase( function( schema ) {
                         return schema.create( "users", function( table ) {
@@ -313,6 +321,15 @@ component extends="testbox.system.BaseSpec" {
                     }, string() );
                 } );
 
+               it( "string (unicode)", function() {
+                    testCase( function( schema ) {
+                        return schema.create( "users", function( table ) {
+                            table.unicodeString( "username" );
+                        }, {}, false );
+                    }, unicodeString() );
+                } );
+
+
                 it( "string (with length)", function() {
                     testCase( function( schema ) {
                         return schema.create( "users", function( table ) {
@@ -327,6 +344,14 @@ component extends="testbox.system.BaseSpec" {
                             table.text( "body" );
                         }, {}, false );
                     }, text() );
+                } );
+
+                 it( "text (unicode)", function() {
+                    testCase( function( schema ) {
+                        return schema.create( "posts", function( table ) {
+                            table.unicodeText( "body" );
+                        }, {}, false );
+                    }, unicodeText() );
                 } );
 
                 it( "time", function() {
@@ -498,7 +523,7 @@ component extends="testbox.system.BaseSpec" {
                         it( "unique (off of column)", function() {
                             testCase( function( schema ) {
                                 return schema.create( "users", function( table ) {
-                                    table.string( "username" ).unique();
+                                    table.unicodeString( "username" ).unique();
                                 }, {}, false );
                             }, columnUnique() );
                         } );
@@ -506,7 +531,7 @@ component extends="testbox.system.BaseSpec" {
                         it( "unique (off of table)", function() {
                             testCase( function( schema ) {
                                 return schema.create( "users", function( table ) {
-                                    table.string( "username" );
+                                    table.unicodeString( "username" );
                                     table.unique( "username" );
                                 }, {}, false );
                             }, tableUnique() );
@@ -515,7 +540,7 @@ component extends="testbox.system.BaseSpec" {
                         it( "unique (overriding constaint name)", function() {
                             testCase( function( schema ) {
                                 return schema.create( "users", function( table ) {
-                                    table.string( "username" );
+                                    table.unicodeString( "username" );
                                     table.unique( "username", "unq_uname" );
                                 }, {}, false );
                             }, uniqueOverridingName() );
@@ -524,8 +549,8 @@ component extends="testbox.system.BaseSpec" {
                         it( "unique (multiple columns)", function() {
                             testCase( function( schema ) {
                                 return schema.create( "users", function( table ) {
-                                    table.string( "first_name" );
-                                    table.string( "last_name" );
+                                    table.unicodeString( "first_name" );
+                                    table.unicodeString( "last_name" );
                                     table.unique( [ "first_name", "last_name" ] );
                                 }, {}, false );
                             }, uniqueMultipleColumns() );
@@ -597,8 +622,8 @@ component extends="testbox.system.BaseSpec" {
                     it( "composite index", function() {
                         testCase( function( schema ) {
                             return schema.create( "users", function( table ) {
-                                table.string( "first_name" );
-                                table.string( "last_name" );
+                                table.unicodeString( "first_name" );
+                                table.unicodeString( "last_name" );
                                 table.index( [ "first_name", "last_name" ] );
                             }, {}, false );
                         }, compositeIndex() );
@@ -607,8 +632,8 @@ component extends="testbox.system.BaseSpec" {
                     it( "override index name", function() {
                         testCase( function( schema ) {
                             return schema.create( "users", function( table ) {
-                                table.string( "first_name" );
-                                table.string( "last_name" );
+                                table.unicodeString( "first_name" );
+                                table.unicodeString( "last_name" );
                                 table.index( [ "first_name", "last_name" ], "index_full_name" );
                             }, {}, false );
                         }, overrideIndexName() );
@@ -636,8 +661,8 @@ component extends="testbox.system.BaseSpec" {
                     it( "composite primary key", function() {
                         testCase( function( schema ) {
                             return schema.create( "users", function( table ) {
-                                table.string( "first_name" );
-                                table.string( "last_name" );
+                                table.unicodeString( "first_name" );
+                                table.unicodeString( "last_name" );
                                 table.primaryKey( [ "first_name", "last_name" ] );
                             }, {}, false );
                         }, compositePrimaryKey() );
@@ -646,8 +671,8 @@ component extends="testbox.system.BaseSpec" {
                     it( "override primary key index name", function() {
                         testCase( function( schema ) {
                             return schema.create( "users", function( table ) {
-                                table.string( "first_name" );
-                                table.string( "last_name" );
+                                table.unicodeString( "first_name" );
+                                table.unicodeString( "last_name" );
                                 table.primaryKey( [ "first_name", "last_name" ], "pk_full_name" );
                             }, {}, false );
                         }, overridePrimaryKeyIndexName() );
@@ -724,7 +749,7 @@ component extends="testbox.system.BaseSpec" {
                 it( "renames a column", function() {
                     testCase( function( schema ) {
                         return schema.alter( "users", function( table ) {
-                            table.renameColumn( "name", table.string( "username" ) );
+                            table.renameColumn( "name", table.unicodeString( "username" ) );
                         }, {}, false );
                     }, renameColumn() );
                 } );
@@ -732,7 +757,7 @@ component extends="testbox.system.BaseSpec" {
                 it( "renames multiple columns", function() {
                     testCase( function( schema ) {
                         return schema.alter( "users", function( table ) {
-                            table.renameColumn( "name", table.string( "username" ) );
+                            table.renameColumn( "name", table.unicodeString( "username" ) );
                             table.renameColumn( "purchase_date", table.timestamp( "purchased_at" ).nullable() );
                         }, {}, false );
                     }, renameMultipleColumns() );
@@ -743,7 +768,7 @@ component extends="testbox.system.BaseSpec" {
                 it( "modifies a column", function() {
                     testCase( function( schema ) {
                         return schema.alter( "users", function( table ) {
-                            table.modifyColumn( "name", table.text( "name" ) );
+                            table.modifyColumn( "name", table.unicodeText( "name" ) );
                         }, {}, false );
                     }, modifyColumn() );
                 } );
@@ -751,7 +776,7 @@ component extends="testbox.system.BaseSpec" {
                 it( "modifies multiple columns", function() {
                     testCase( function( schema ) {
                         return schema.alter( "users", function( table ) {
-                            table.modifyColumn( "name", table.text( "name" ) );
+                            table.modifyColumn( "name", table.unicodeText( "name" ) );
                             table.modifyColumn( "purchase_date", table.timestamp( "purchased_date" ).nullable() );
                         }, {}, false );
                     }, modifyMultipleColumns() );
@@ -782,7 +807,7 @@ component extends="testbox.system.BaseSpec" {
                     return schema.alter( "users", function( table ) {
                         table.dropColumn( "is_active" );
                         table.addColumn( table.enum( "tshirt_size", [ "S", "M", "L", "XL", "XXL" ] ) );
-                        table.renameColumn( "name", table.string( "username" ) );
+                        table.renameColumn( "name", table.unicodeString( "username" ) );
                         table.modifyColumn( "purchase_date", table.timestamp( "purchase_date" ).nullable() );
                         table.addConstraint( table.unique( "username" ) );
                         table.addConstraint( table.unique( "email" ) );

--- a/tests/specs/Schema/MSSQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MSSQLSchemaBuilderSpec.cfc
@@ -101,11 +101,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function json() {
-        return [ "CREATE TABLE [users] ([personalizations] NTEXT NOT NULL)" ];
+        return [ "CREATE TABLE [users] ([personalizations] NVARCHAR(MAX) NOT NULL)" ];
     }
 
     function longText() {
-        return [ "CREATE TABLE [posts] ([body] NTEXT NOT NULL)" ];
+        return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
     function mediumIncrements() {
@@ -121,7 +121,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function mediumText() {
-        return [ "CREATE TABLE [posts] ([body] NTEXT NOT NULL)" ];
+        return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
     function morphs() {
@@ -157,7 +157,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function text() {
-        return [ "CREATE TABLE [posts] ([body] NTEXT NOT NULL)" ];
+        return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
     function time() {
@@ -345,12 +345,12 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function modifyColumn() {
-        return [ "ALTER TABLE [users] ALTER COLUMN [name] NTEXT NOT NULL" ];
+        return [ "ALTER TABLE [users] ALTER COLUMN [name] NVARCHAR(MAX) NOT NULL" ];
     }
 
     function modifyMultipleColumns() {
         return [
-            "ALTER TABLE [users] ALTER COLUMN [name] NTEXT NOT NULL",
+            "ALTER TABLE [users] ALTER COLUMN [name] NVARCHAR(MAX) NOT NULL",
             "ALTER TABLE [users] ALTER COLUMN [purchased_date] DATETIME2"
         ];
     }

--- a/tests/specs/Schema/MSSQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MSSQLSchemaBuilderSpec.cfc
@@ -105,6 +105,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function longText() {
+        return [ "CREATE TABLE [posts] ([body] VARCHAR(MAX) NOT NULL)" ];
+    }
+
+    function unicodeLongText() {
         return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
@@ -121,15 +125,19 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function mediumText() {
+        return [ "CREATE TABLE [posts] ([body] VARCHAR(MAX) NOT NULL)" ];
+    }
+
+    function mediumUnicodeText() {
         return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
     function morphs() {
-        return [ "CREATE TABLE [tags] ([taggable_id] INTEGER NOT NULL, [taggable_type] NVARCHAR(255) NOT NULL, INDEX [taggable_index] ([taggable_id], [taggable_type]))" ];
+        return [ "CREATE TABLE [tags] ([taggable_id] INTEGER NOT NULL, [taggable_type] VARCHAR(255) NOT NULL, INDEX [taggable_index] ([taggable_id], [taggable_type]))" ];
     }
 
     function nullableMorphs() {
-        return [ "CREATE TABLE [tags] ([taggable_id] INTEGER, [taggable_type] NVARCHAR(255), INDEX [taggable_index] ([taggable_id], [taggable_type]))" ];
+        return [ "CREATE TABLE [tags] ([taggable_id] INTEGER, [taggable_type] VARCHAR(255), INDEX [taggable_index] ([taggable_id], [taggable_type]))" ];
     }
 
     function raw() {
@@ -149,14 +157,22 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function string() {
+        return [ "CREATE TABLE [users] ([username] VARCHAR(255) NOT NULL)" ];
+    }
+
+    function unicodeString() {
         return [ "CREATE TABLE [users] ([username] NVARCHAR(255) NOT NULL)" ];
     }
 
     function stringWithLength() {
-        return [ "CREATE TABLE [users] ([password] NVARCHAR(50) NOT NULL)" ];
+        return [ "CREATE TABLE [users] ([password] VARCHAR(50) NOT NULL)" ];
     }
 
     function text() {
+        return [ "CREATE TABLE [posts] ([body] VARCHAR(MAX) NOT NULL)" ];
+    }
+
+    function unicodeText() {
         return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
@@ -298,11 +314,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function columnPrimaryKey() {
-        return [ "CREATE TABLE [users] ([uuid] NVARCHAR(255) NOT NULL, CONSTRAINT [pk_users_uuid] PRIMARY KEY ([uuid]))" ];
+        return [ "CREATE TABLE [users] ([uuid] VARCHAR(255) NOT NULL, CONSTRAINT [pk_users_uuid] PRIMARY KEY ([uuid]))" ];
     }
 
     function tablePrimaryKey() {
-        return [ "CREATE TABLE [users] ([uuid] NVARCHAR(255) NOT NULL, CONSTRAINT [pk_users_uuid] PRIMARY KEY ([uuid]))" ];
+        return [ "CREATE TABLE [users] ([uuid] VARCHAR(255) NOT NULL, CONSTRAINT [pk_users_uuid] PRIMARY KEY ([uuid]))" ];
     }
 
     function compositePrimaryKey() {

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -110,6 +110,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
     }
 
+     function UnicodeLongText() {
+        return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
+    }
+
     function mediumIncrements() {
         return [ "CREATE TABLE `users` (`id` MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT, CONSTRAINT `pk_users_id` PRIMARY KEY (`id`))" ];
     }
@@ -127,11 +131,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function morphs() {
-        return [ "CREATE TABLE `tags` (`taggable_id` INTEGER UNSIGNED NOT NULL, `taggable_type` NVARCHAR(255) NOT NULL, INDEX `taggable_index` (`taggable_id`, `taggable_type`))" ];
+        return [ "CREATE TABLE `tags` (`taggable_id` INTEGER UNSIGNED NOT NULL, `taggable_type` VARCHAR(255) NOT NULL, INDEX `taggable_index` (`taggable_id`, `taggable_type`))" ];
     }
 
     function nullableMorphs() {
-        return [ "CREATE TABLE `tags` (`taggable_id` INTEGER UNSIGNED, `taggable_type` NVARCHAR(255), INDEX `taggable_index` (`taggable_id`, `taggable_type`))" ];
+        return [ "CREATE TABLE `tags` (`taggable_id` INTEGER UNSIGNED, `taggable_type` VARCHAR(255), INDEX `taggable_index` (`taggable_id`, `taggable_type`))" ];
     }
 
     function raw() {
@@ -151,14 +155,22 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function string() {
-        return [ "CREATE TABLE `users` (`username` NVARCHAR(255) NOT NULL)" ];
+        return [ "CREATE TABLE `users` (`username` VARCHAR(255) NOT NULL)" ];
     }
 
     function stringWithLength() {
-        return [ "CREATE TABLE `users` (`password` NVARCHAR(50) NOT NULL)" ];
+        return [ "CREATE TABLE `users` (`password` VARCHAR(50) NOT NULL)" ];
+    }
+
+    function unicodeString() {
+        return [ "CREATE TABLE `users` (`username` NVARCHAR(255) NOT NULL)" ];
     }
 
     function text() {
+        return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
+    }
+
+    function unicodeText() {
         return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
     }
 
@@ -300,11 +312,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function columnPrimaryKey() {
-        return [ "CREATE TABLE `users` (`uuid` NVARCHAR(255) NOT NULL, CONSTRAINT `pk_users_uuid` PRIMARY KEY (`uuid`))" ];
+        return [ "CREATE TABLE `users` (`uuid` VARCHAR(255) NOT NULL, CONSTRAINT `pk_users_uuid` PRIMARY KEY (`uuid`))" ];
     }
 
     function tablePrimaryKey() {
-        return [ "CREATE TABLE `users` (`uuid` NVARCHAR(255) NOT NULL, CONSTRAINT `pk_users_uuid` PRIMARY KEY (`uuid`))" ];
+        return [ "CREATE TABLE `users` (`uuid` VARCHAR(255) NOT NULL, CONSTRAINT `pk_users_uuid` PRIMARY KEY (`uuid`))" ];
     }
 
     function compositePrimaryKey() {

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -120,6 +120,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""POSTS"" (""BODY"" CLOB NOT NULL)" ];
     }
 
+    function unicodeLongText() {
+        return longText();
+    }
+
     function mediumIncrements() {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(7, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
@@ -178,12 +182,20 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""USERS"" (""USERNAME"" VARCHAR2(255) NOT NULL)" ];
     }
 
+    function unicodeString() {
+        return string();
+    }
+
     function stringWithLength() {
         return [ "CREATE TABLE ""USERS"" (""PASSWORD"" VARCHAR2(50) NOT NULL)" ];
     }
 
     function text() {
         return [ "CREATE TABLE ""POSTS"" (""BODY"" CLOB NOT NULL)" ];
+    }
+
+    function unicodeText() {
+        return text();
     }
 
     function time() {

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -111,6 +111,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
     }
 
+    function unicodeLongText() {
+        return longText();
+    }
+
     function mediumIncrements() {
         return [ "CREATE TABLE ""users"" (""id"" SERIAL NOT NULL, CONSTRAINT ""pk_users_id"" PRIMARY KEY (""id""))" ];
     }
@@ -161,12 +165,20 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""users"" (""username"" VARCHAR(255) NOT NULL)" ];
     }
 
+    function unicodeString() {
+        return string();
+    }
+
     function stringWithLength() {
         return [ "CREATE TABLE ""users"" (""password"" VARCHAR(50) NOT NULL)" ];
     }
 
     function text() {
         return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function unicodeText() {
+        return text();
     }
 
     function time() {


### PR DESCRIPTION
This isn't ready for prime time yet but I think it's pretty close, depending on some assumptions I made about how and when unicodeString should be employed. 

It's failing two postgres tests related to ALTER TABLE where it relies on the getType() and the approach I took for this is inconsistent with the assumption that getType() will always return a valid data type for your grammar – or else there's an easy way to make UNICODETEXT just TEXT for that grammar that I missed. I didn't see right away where to override the type set in the blueprint for cases where a grammar doesn't actually have a datatype and you need it to behave like a different one.