### PR TITLE
Add returning function for compatible grammars

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -78,7 +78,7 @@ component displayname="Grammar" accessors="true" {
         data.query = isNull( q ) ? javacast( "null", "" ) : q;
         data.result = local.result;
         tryPostInterceptor( data );
-        return returnObject == "result" ? local.result : q;
+        return returnObject == "query" ? q : { result = local.result, query = q };
     }
 
     /**
@@ -879,7 +879,7 @@ component displayname="Grammar" accessors="true" {
         if ( utils.isExpression( column ) ) {
             return column.getSql();
         }
-        
+
         try {
             if (!column.isColumn()) {
                 throw(message="Not a Column");

--- a/models/Grammars/MSSQLGrammar.cfc
+++ b/models/Grammars/MSSQLGrammar.cfc
@@ -9,6 +9,33 @@ component extends="qb.models.Grammars.BaseGrammar" {
     ];
 
     /**
+    * Compile a Builder's query into an insert string.
+    *
+    * @query The Builder instance.
+    * @columns The array of columns into which to insert.
+    * @values The array of values to insert.
+    *
+    * @return string
+    */
+    public string function compileInsert(
+        required query,
+        required array columns,
+        required array values
+    ) {
+        var columnsString = columns.map( wrapColumn ).toList( ", " );
+        var returningColumns = query.getReturning().map( function( column ) {
+            return "INSERTED." & wrapColumn( column );
+        } ).toList( ", " );
+        var returningClause = returningColumns != "" ? " OUTPUT #returningColumns#" : "";
+        var placeholderString = values.map( function( valueArray ) {
+            return "(" & valueArray.map( function() {
+                return "?";
+            } ).toList( ", " ) & ")";
+        } ).toList( ", ");
+        return trim( "INSERT INTO #wrapTable( query.getFrom() )# (#columnsString#)#returningClause# VALUES #placeholderString#" );
+    }
+
+    /**
     * Compiles the Common Table Expressions (CTEs).
     *
     * @query The Builder instance.

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -64,6 +64,29 @@ component extends="qb.models.Grammars.BaseGrammar" {
         return tables;
     }
 
+    /**
+    * Compile a Builder's query into an insert string.
+    *
+    * @query The Builder instance.
+    * @columns The array of columns into which to insert.
+    * @values The array of values to insert.
+    *
+    * @return string
+    */
+    public string function compileInsert(
+        required QueryBuilder query,
+        required array columns,
+        required array values
+    ) {
+        if ( ! query.getReturning().isEmpty() ) {
+            throw(
+                type = "UnsupportedOperation",
+                message = "This grammar does not support a RETURNING clause"
+            );
+        }
+        return super.compileInsert( argumentCollection = arguments );
+    }
+
     function compileDisableForeignKeyConstraints() {
         return "SET FOREIGN_KEY_CHECKS=0";
     }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -62,6 +62,13 @@ component extends="qb.models.Grammars.BaseGrammar" {
     * @return string
     */
     public string function compileInsert( required QueryBuilder query, required array columns, required array values ) {
+        if ( ! query.getReturning().isEmpty() ) {
+            throw(
+                type = "UnsupportedOperation",
+                message = "This grammar does not support a RETURNING clause"
+            );
+        }
+
         var columnsString = columns.map( wrapColumn ).toList( ", " );
 
         var placeholderString = values.map( function( valueArray ) {

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -1,5 +1,24 @@
 component extends="qb.models.Grammars.BaseGrammar" {
 
+    /**
+    * Compile a Builder's query into an insert string.
+    *
+    * @query The Builder instance.
+    * @columns The array of columns into which to insert.
+    * @values The array of values to insert.
+    *
+    * @return string
+    */
+    public string function compileInsert(
+        required query,
+        required array columns,
+        required array values
+    ) {
+        var returningColumns = query.getReturning().map( wrapColumn ).toList( ", " );
+        var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+        return super.compileInsert( argumentCollection = arguments ) & returningClause;
+    }
+
     /*===================================
     =              Schema               =
     ===================================*/

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -106,6 +106,12 @@ component displayname="QueryBuilder" accessors="true" {
     property name="offsetValue" type="numeric";
 
     /**
+    * An array of columns to return from an insert statement.
+    * @default []
+    */
+    property name="returning" type="array";
+
+    /**
     * The list of allowed operators in join and where statements.
     */
     variables.operators = [
@@ -184,6 +190,7 @@ component displayname="QueryBuilder" accessors="true" {
         variables.havings = [];
         variables.orders = [];
         variables.unions = [];
+        variables.returning = [];
     }
 
     /**********************************************************************************************\
@@ -1830,6 +1837,13 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         return runQuery( sql, options, "result" );
+    }
+
+    function returning( required any columns ) {
+        variables.returning = isArray( arguments.columns ) ?
+            arguments.columns :
+            listToArray( arguments.columns );
+        return this;
     }
 
     /**

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1005,7 +1005,7 @@ component extends="testbox.system.BaseSpec" {
                         testCase( function( builder ) {
                             var union2 = getBuilder().select("name").from("users").where( "id", 2 );
                             var union3 = getBuilder().select("name").from("users").where( "id", 3 );
-                            
+
                             builder
                                 .select("name")
                                 .from( "users" )
@@ -1111,7 +1111,7 @@ component extends="testbox.system.BaseSpec" {
                         testCase( function( builder ) {
                             var union2 = getBuilder().select("name").from("users").where( "id", 2 );
                             var union3 = getBuilder().select("name").from("users").where( "id", 3 );
-                            
+
                             builder
                                 .select("name")
                                 .from( "users" )
@@ -1302,6 +1302,15 @@ component extends="testbox.system.BaseSpec" {
                             { "email" = "baz", "name" = "bleh" }
                         ], toSql = true );
                     }, batchInsert() );
+                } );
+
+                it( "can insert with returning", function() {
+                    testCase( function( builder ) {
+                        return builder.from( "users" ).returning( "id" ).insert( values = {
+                            "email" = "foo",
+                            "name" = "bar"
+                        }, toSql = true );
+                    }, returning() );
                 } );
             } );
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1388,24 +1388,33 @@ component extends="testbox.system.BaseSpec" {
     }
 
     private function testCase( callback, expected ) {
-        var builder = getBuilder();
-        var sql = callback( builder );
-        if ( ! isNull( sql ) ) {
-            if ( ! isSimpleValue( sql ) ) {
-                sql = sql.toSQL();
+        try {
+            var builder = getBuilder();
+            var sql = callback( builder );
+            if ( ! isNull( sql ) ) {
+                if ( ! isSimpleValue( sql ) ) {
+                    sql = sql.toSQL();
+                }
             }
+            else {
+                sql = builder.toSQL();
+            }
+            if ( isSimpleValue( expected ) ) {
+                expected = {
+                    sql = expected,
+                    bindings = []
+                };
+            }
+            expect( sql ).toBeWithCase( expected.sql );
+            expect( getTestBindings( builder ) ).toBe( expected.bindings );
         }
-        else {
-            sql = builder.toSQL();
+        catch ( any e ) {
+            if ( structKeyExists( expected, "exception" ) ) {
+                expect( e.type ).toBe( expected.exception );
+                return;
+            }
+            rethrow;
         }
-        if ( isSimpleValue( expected ) ) {
-            expected = {
-                sql = expected,
-                bindings = []
-            };
-        }
-        expect( sql ).toBeWithCase( expected.sql );
-        expect( getTestBindings( builder ) ).toBe( expected.bindings );
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
@@ -578,6 +578,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function returning() {
+        return {
+            sql = "INSERT INTO [users] ([email], [name]) OUTPUT INSERTED.[id] VALUES (?, ?)",
+            bindings = [ "foo", "bar" ]
+        };
+    }
+
     function updateAllRecords() {
         return {
             sql = "UPDATE [users] SET [email] = ?, [name] = ?",

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -580,8 +580,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function returning() {
         return {
-            sql = "INSERT INTO `users` (`email`, `name`) VALUES (?, ?)",
-            bindings = [ "foo", "bar" ]
+            exception = "UnsupportedOperation"
         };
     }
 

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -578,6 +578,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function returning() {
+        return {
+            sql = "INSERT INTO `users` (`email`, `name`) VALUES (?, ?)",
+            bindings = [ "foo", "bar" ]
+        };
+    }
+
     function updateAllRecords() {
         return {
             sql = "UPDATE `users` SET `email` = ?, `name` = ?",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -578,6 +578,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function returning() {
+        return {
+            sql = "INSERT ALL INTO ""USERS"" (""EMAIL"", ""NAME"") VALUES (?, ?) SELECT 1 FROM dual",
+            bindings = [ "foo", "bar" ]
+        };
+    }
+
     function updateAllRecords() {
         return {
             sql = "UPDATE ""USERS"" SET ""EMAIL"" = ?, ""NAME"" = ?",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -580,8 +580,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function returning() {
         return {
-            sql = "INSERT ALL INTO ""USERS"" (""EMAIL"", ""NAME"") VALUES (?, ?) SELECT 1 FROM dual",
-            bindings = [ "foo", "bar" ]
+            exception = "UnsupportedOperation"
         };
     }
 

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -578,6 +578,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function returning() {
+        return {
+            sql = "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?) RETURNING ""id""",
+            bindings = [ "foo", "bar" ]
+        };
+    }
+
     function updateAllRecords() {
         return {
             sql = "UPDATE ""users"" SET ""email"" = ?, ""name"" = ?",


### PR DESCRIPTION
This PR adds a `returning` function on the QueryBuilder.  This function is used with compatible grammars to bring back selected columns from an insert statement.

It is still in question whether this is a good idea since only two of the four grammars actually do anything with it.  But it is useful for some use cases in Quick, so ¯\_(ツ)_/¯