### PR TITLE
feat(QueryBuilder): Add a columnFormatter option

### DIFF
--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -22,7 +22,7 @@ component extends="qb.models.Grammars.BaseGrammar" {
     * @return string
     */
     public string function wrapAlias( required any value ) {
-        return """#value#""";
+        return "`#value#`";
     }
 
     function compileRenameTable( blueprint, commandParameters ) {

--- a/tests/specs/Query/Abstract/BuilderColumnCallbackSpec.cfc
+++ b/tests/specs/Query/Abstract/BuilderColumnCallbackSpec.cfc
@@ -1,0 +1,27 @@
+component extends="testbox.system.BaseSpec" {
+
+    function run() {
+        describe( "column callback spec", function() {
+            beforeEach( function() {
+                variables.query = new qb.models.Query.QueryBuilder();
+                getMockBox().prepareMock( query );
+                query.$property( propertyName = "utils", mock = new qb.models.Query.QueryUtils() );
+            } );
+
+            it( "does nothing by default", function() {
+                query.from( "users" ).where( "firstName", "=", "firstName" );
+                expect( query.toSQL() ).toBe( 'SELECT * FROM "users" WHERE "firstName" = ?' );
+                expect( query.getBindings()[ 1 ].value ).toBe( "firstName" );
+            } );
+
+            it( "can set a column formatter to be called for each column used", function() {
+                query.setColumnFormatter( function( column ) {
+                    return reverse( column );
+                } );
+                query.from( "users" ).where( "firstName", "=", "firstName" );
+                expect( query.toSQL() ).toBe( 'SELECT * FROM "users" WHERE "emaNtsrif" = ?' );
+                expect( query.getBindings()[ 1 ].value ).toBe( "firstName" );
+            } );
+        } );
+    }
+}

--- a/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MSSQLQueryBuilderSpec.cfc
@@ -65,7 +65,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function fromDerivedTable() {
         return {
-            sql = "SELECT * FROM (SELECT [id], [name] FROM [users] WHERE [age] >= ?) as [u]",
+            sql = "SELECT * FROM (SELECT [id], [name] FROM [users] WHERE [age] >= ?) AS [u]",
             bindings = [21]
         };
     }
@@ -353,28 +353,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function joinSub() {
         return {
-            sql = 'SELECT * FROM [users] AS [u] INNER JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) as [c] ON [u].[id] = [c].[id]',
+            sql = 'SELECT * FROM [users] AS [u] INNER JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) AS [c] ON [u].[id] = [c].[id]',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function leftJoinSub() {
         return {
-            sql = 'SELECT * FROM [users] AS [u] LEFT JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) as [c] ON [u].[id] = [c].[id]',
+            sql = 'SELECT * FROM [users] AS [u] LEFT JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) AS [c] ON [u].[id] = [c].[id]',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function rightJoinSub() {
         return {
-            sql = 'SELECT * FROM [users] AS [u] RIGHT JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) as [c] ON [u].[id] = [c].[id]',
+            sql = 'SELECT * FROM [users] AS [u] RIGHT JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) AS [c] ON [u].[id] = [c].[id]',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function crossJoinSub() {
         return {
-            sql = 'SELECT * FROM [users] AS [u] CROSS JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) as [c]',
+            sql = 'SELECT * FROM [users] AS [u] CROSS JOIN (SELECT [id] FROM [contacts] WHERE [id] NOT IN (?, ?, ?)) AS [c]',
             bindings = [ 1, 2, 3 ]
         };
     }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -45,12 +45,12 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function subSelect() {
-        return "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id` ) AS ""latestUpdatedDate"" FROM `users`";
+        return "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id` ) AS `latestUpdatedDate` FROM `users`";
     }
 
     function subSelectWithBindings() {
         return {
-            sql = "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = ? ) AS ""latestUpdatedDate"" FROM `users`",
+            sql = "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = ? ) AS `latestUpdatedDate` FROM `users`",
             bindings = [ 1 ]
         };
     }
@@ -65,7 +65,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function fromDerivedTable() {
         return {
-            sql = "SELECT * FROM (SELECT `id`, `name` FROM `users` WHERE `age` >= ?) as ""u""",
+            sql = "SELECT * FROM (SELECT `id`, `name` FROM `users` WHERE `age` >= ?) AS `u`",
             bindings = [21]
         };
     }
@@ -353,28 +353,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function joinSub() {
         return {
-            sql = 'SELECT * FROM `users` AS `u` INNER JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) as "c" ON `u`.`id` = `c`.`id`',
+            sql = 'SELECT * FROM `users` AS `u` INNER JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) AS `c` ON `u`.`id` = `c`.`id`',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function leftJoinSub() {
         return {
-            sql = 'SELECT * FROM `users` AS `u` LEFT JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) as "c" ON `u`.`id` = `c`.`id`',
+            sql = 'SELECT * FROM `users` AS `u` LEFT JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) AS `c` ON `u`.`id` = `c`.`id`',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function rightJoinSub() {
         return {
-            sql = 'SELECT * FROM `users` AS `u` RIGHT JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) as "c" ON `u`.`id` = `c`.`id`',
+            sql = 'SELECT * FROM `users` AS `u` RIGHT JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) AS `c` ON `u`.`id` = `c`.`id`',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function crossJoinSub() {
         return {
-            sql = 'SELECT * FROM `users` AS `u` CROSS JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) as "c"',
+            sql = 'SELECT * FROM `users` AS `u` CROSS JOIN (SELECT `id` FROM `contacts` WHERE `id` NOT IN (?, ?, ?)) AS `c`',
             bindings = [ 1, 2, 3 ]
         };
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -65,7 +65,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function fromDerivedTable() {
         return {
-            sql = "SELECT * FROM (SELECT ""ID"", ""NAME"" FROM ""USERS"" WHERE ""AGE"" >= ?) as ""U""",
+            sql = "SELECT * FROM (SELECT ""ID"", ""NAME"" FROM ""USERS"" WHERE ""AGE"" >= ?) AS ""U""",
             bindings = [21]
         };
     }
@@ -353,28 +353,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function joinSub() {
         return {
-            sql = 'SELECT * FROM "USERS" AS "U" INNER JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) as "C" ON "U"."ID" = "C"."ID"',
+            sql = 'SELECT * FROM "USERS" AS "U" INNER JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) AS "C" ON "U"."ID" = "C"."ID"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function leftJoinSub() {
         return {
-            sql = 'SELECT * FROM "USERS" AS "U" LEFT JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) as "C" ON "U"."ID" = "C"."ID"',
+            sql = 'SELECT * FROM "USERS" AS "U" LEFT JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) AS "C" ON "U"."ID" = "C"."ID"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function rightJoinSub() {
         return {
-            sql = 'SELECT * FROM "USERS" AS "U" RIGHT JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) as "C" ON "U"."ID" = "C"."ID"',
+            sql = 'SELECT * FROM "USERS" AS "U" RIGHT JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) AS "C" ON "U"."ID" = "C"."ID"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function crossJoinSub() {
         return {
-            sql = 'SELECT * FROM "USERS" AS "U" CROSS JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) as "C"',
+            sql = 'SELECT * FROM "USERS" AS "U" CROSS JOIN (SELECT "ID" FROM "CONTACTS" WHERE "ID" NOT IN (?, ?, ?)) AS "C"',
             bindings = [ 1, 2, 3 ]
         };
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -65,7 +65,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function fromDerivedTable() {
         return {
-            sql = "SELECT * FROM (SELECT ""id"", ""name"" FROM ""users"" WHERE ""age"" >= ?) as ""u""",
+            sql = "SELECT * FROM (SELECT ""id"", ""name"" FROM ""users"" WHERE ""age"" >= ?) AS ""u""",
             bindings = [21]
         };
     }
@@ -353,28 +353,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function joinSub() {
         return {
-            sql = 'SELECT * FROM "users" AS "u" INNER JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) as "c" ON "u"."id" = "c"."id"',
+            sql = 'SELECT * FROM "users" AS "u" INNER JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) AS "c" ON "u"."id" = "c"."id"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function leftJoinSub() {
         return {
-            sql = 'SELECT * FROM "users" AS "u" LEFT JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) as "c" ON "u"."id" = "c"."id"',
+            sql = 'SELECT * FROM "users" AS "u" LEFT JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) AS "c" ON "u"."id" = "c"."id"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function rightJoinSub() {
         return {
-            sql = 'SELECT * FROM "users" AS "u" RIGHT JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) as "c" ON "u"."id" = "c"."id"',
+            sql = 'SELECT * FROM "users" AS "u" RIGHT JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) AS "c" ON "u"."id" = "c"."id"',
             bindings = [ 1, 2, 3 ]
         };
     }
 
     function crossJoinSub() {
         return {
-            sql = 'SELECT * FROM "users" AS "u" CROSS JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) as "c"',
+            sql = 'SELECT * FROM "users" AS "u" CROSS JOIN (SELECT "id" FROM "contacts" WHERE "id" NOT IN (?, ?, ?)) AS "c"',
             bindings = [ 1, 2, 3 ]
         };
     }


### PR DESCRIPTION
A column formatter has the chance to influence
columns before they are added to the query.  This
is mainly used by Quick to transform aliases to
columns before adding it to the query.