### PR TITLE
Allow uppercase sql operators - Fixes #69

### DIFF
--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2661,7 +2661,7 @@ component displayname="QueryBuilder" accessors="true" {
     * @return boolean
     */
     private boolean function isInvalidOperator( required string operator ) {
-        return ! arrayContains( operators, operator );
+        return ! arrayContains( operators, lcase(operator) );
     }
 
     /**
@@ -2672,12 +2672,7 @@ component displayname="QueryBuilder" accessors="true" {
     * @return boolean
     */
     private boolean function isInvalidCombinator( required string combinator ) {
-        for ( var validCombinator in variables.combinators ) {
-            if ( validCombinator == arguments.combinator ) {
-                return false;
-            }
-        }
-        return true;
+        return ! arrayContains( variables.combinators, ucase(arguments.combinator) );
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2661,7 +2661,7 @@ component displayname="QueryBuilder" accessors="true" {
     * @return boolean
     */
     private boolean function isInvalidOperator( required string operator ) {
-        return ! arrayContains( operators, lcase(operator) );
+        return ! arrayContains( variables.operators, lcase( arguments.operator ) );
     }
 
     /**
@@ -2672,7 +2672,7 @@ component displayname="QueryBuilder" accessors="true" {
     * @return boolean
     */
     private boolean function isInvalidCombinator( required string combinator ) {
-        return ! arrayContains( variables.combinators, ucase(arguments.combinator) );
+        return ! arrayContains( variables.combinators, ucase( arguments.combinator ) );
     }
 
     /**


### PR DESCRIPTION
Forcing lowercase operators allows `arrayContains()` to match regardless
of case.

I also took the liberty of refactoring the `isInvalidCombinator()`
function to match - so both functions are non-case-sensitive and use
`arrayContains()`. It was pretty obvious that `isInvalidCombinator()`
was written with flexible casing in mind, whereas `isInvalidOperator()`
was not.

Please note I made sure tests pass before committing. :)