### PR TITLE
Add pagination collectors to qb

### DIFF
--- a/box.json
+++ b/box.json
@@ -31,6 +31,9 @@
             "URL":"https://github.com/coldbox-modules/qb/LICENSE"
         }
     ],
+    "dependencies":{
+        "cbpaginator":"^1.3.0"
+    },
     "devDependencies":{
         "testbox":"^3.0.0"
     },
@@ -53,8 +56,5 @@
     "testbox":{
         "runner":"http://localhost:7777/tests/runner.cfm",
         "verbose": false
-    },
-    "dependencies":{
-        "cbpaginator":"github:quinteroj/pagination#89cb669"
     }
 }

--- a/box.json
+++ b/box.json
@@ -55,6 +55,6 @@
         "verbose": false
     },
     "dependencies":{
-        "cbpaginator":"^1.2.0"
+        "cbpaginator":"github:quinteroj/pagination#89cb669"
     }
 }

--- a/box.json
+++ b/box.json
@@ -35,7 +35,8 @@
         "testbox":"^3.0.0"
     },
     "installPaths":{
-        "testbox":"testbox/"
+        "testbox":"testbox/",
+        "cbpaginator":"modules/cbpaginator/"
     },
     "ignore":[
         "**/.*",
@@ -52,5 +53,8 @@
     "testbox":{
         "runner":"http://localhost:7777/tests/runner.cfm",
         "verbose": false
+    },
+    "dependencies":{
+        "cbpaginator":"^1.2.0"
     }
 }

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -1734,29 +1734,27 @@ component displayname="QueryBuilder" accessors="true" {
     /**
     * Helper method to calculate the limit and offset given a page number and count per page.
     *
-    * @pageNumber The page number to retrieve
-    * @pageCount The number of records per page.
+    * @page The page number to retrieve
+    * @maxRows The number of records per page.
     *
     * @return qb.models.Query.QueryBuilder
     */
     public QueryBuilder function forPage(
-        required numeric pageNumber,
-        required numeric pageCount
+        required numeric page,
+        required numeric maxRows
     ) {
-        arguments.pageCount = arguments.pageCount > 0 ? arguments.pageCount : 0;
-        offset( arguments.pageNumber * arguments.pageCount - arguments.pageCount );
-        limit( arguments.pageCount );
+        arguments.maxRows = arguments.maxRows > 0 ? arguments.maxRows : 0;
+        offset( arguments.page * arguments.maxRows - arguments.maxRows );
+        limit( arguments.maxRows );
         return this;
     }
 
     public any function paginate(
-        required numeric page = 1,
-        required numeric maxRows = 25
+        numeric page = 1,
+        numeric maxRows = 25
     ) {
         var totalRecords = count();
-        var results = withReturnFormat( "array", function() {
-            return forPage( page, maxRows ).get();
-        } );
+        var results = forPage( page, maxRows ).get();
         return getPaginationCollector().generateWithResults(
             totalRecords = totalRecords,
             results = results,

--- a/tests/specs/Query/Abstract/PaginationSpec.cfc
+++ b/tests/specs/Query/Abstract/PaginationSpec.cfc
@@ -1,0 +1,124 @@
+component extends="testbox.system.BaseSpec" {
+
+    function run() {
+        describe( "pagination", function() {
+            it( "returns the default pagination object", function() {
+                var builder = getBuilder();
+                var expectedResults = [];
+                for ( var i = 1; i <= 25; i++ ) {
+                    expectedResults.append( { "id" = i } );
+                }
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 45 );
+                builder.$( "runQuery", expectedQuery );
+
+                var results = builder.from( "users" ).paginate();
+
+                expect( results ).toBe( {
+                    "pagination": {
+                        "maxRows": 25,
+                        "offset": 0,
+                        "page": 1,
+                        "totalPages": 2,
+                        "totalRecords": 45
+                    },
+                    "results": expectedResults
+                } );
+            } );
+
+            it( "can get results for subsequent pages", function() {
+                var builder = getBuilder();
+                var expectedResults = [];
+                for ( var i = 26; i <= 45; i++ ) {
+                    expectedResults.append( { "id" = i } );
+                }
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 45 );
+                builder.$( "runQuery", expectedQuery );
+
+                var results = builder.from( "users" ).paginate( page = 2 );
+
+                expect( results ).toBe( {
+                    "pagination": {
+                        "maxRows": 25,
+                        "offset": 25,
+                        "page": 2,
+                        "totalPages": 2,
+                        "totalRecords": 45
+                    },
+                    "results": expectedResults
+                } );
+            } );
+
+            it( "can provide a custom amount per page", function() {
+                var builder = getBuilder();
+                var expectedResults = [];
+                for ( var i = 1; i <= 10; i++ ) {
+                    expectedResults.append( { "id" = i } );
+                }
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 45 );
+                builder.$( "runQuery", expectedQuery );
+
+                var results = builder.from( "users" ).paginate( page = 1, maxRows = 10);
+
+                expect( results ).toBe( {
+                    "pagination": {
+                        "maxRows": 10,
+                        "offset": 0,
+                        "page": 1,
+                        "totalPages": 5,
+                        "totalRecords": 45
+                    },
+                    "results": expectedResults
+                } );
+            } );
+
+            it( "can provide a custom paginator shell", function() {
+                var builder = getBuilder();
+                builder.setPaginationCollector( {
+                    "generateWithResults" = function( totalRecords, results, page, maxRows ) {
+                        return {
+                            "total": totalRecords,
+                            "pageNumber": page,
+                            "limit": maxRows,
+                            "data": results
+                        };
+                    }
+                } );
+                var expectedResults = [];
+                for ( var i = 1; i <= 25; i++ ) {
+                    expectedResults.append( { "id" = i } );
+                }
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 45 );
+                builder.$( "runQuery", expectedQuery );
+
+                var results = builder.from( "users" ).paginate();
+
+                expect( results ).toBe( {
+                    "total": 45,
+                    "pageNumber": 1,
+                    "limit": 25,
+                    "data": expectedResults
+                } );
+            } );
+        } );
+    }
+
+    private function getBuilder() {
+        var grammar = getMockBox()
+            .createMock( "qb.models.Grammars.BaseGrammar" )
+            .init();
+        var builder = getMockBox().createMock( "qb.models.Query.QueryBuilder" )
+            .init( grammar );
+        return builder;
+    }
+
+    private array function getTestBindings( builder ) {
+        return builder.getBindings().map( function( binding ) {
+            return binding.value;
+        } );
+    }
+
+}


### PR DESCRIPTION
Pagination collectors allow qb to help with pagination by
abstracting to a concept of a page and by collecting
relevant pagination data into a struct returned with
the results of the query.

```
{
    "totalRecords": 45,
    "maxRows": 25,
    "totalPages": 2,
    "page": 2,
    "offset": 25,
    "results": [ /* ... */ ]
}
```