### PR TITLE
fix(QueryUtils): Fix array normalization to handle non-string inputs

### DIFF
--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2569,9 +2569,13 @@ component displayname="QueryBuilder" accessors="true" {
             return [ arguments.listOrArray ];
         }
 
-        var cfArray = [];
-        cfArray.append( trim( arguments.listOrArray ).split( ",\s*" ), true );
-        return cfArray;
+        try {
+            var cfArray = [];
+            cfArray.append( trim( arguments.listOrArray ).split( ",\s*" ), true );
+            return cfArray;
+        } catch ( any e ) {
+            return arguments.listOrArray;
+        }
     }
 
     /**


### PR DESCRIPTION
`normalizeToArray` tries to `split` a string using a regex.  This fails
on non-string values like single digits.  There may be a better way,
but for now we are doing a try / catch on the split and returning
the original value if the `split` fails.