### PR TITLE
feat(QueryBuilder): Enhance order by's with more direction options

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -608,13 +608,12 @@ component displayname="Grammar" accessors="true" singleton {
         }
 
         var orderBys = orders.map( function( orderBy ) {
-            switch ( orderBy.direction ) {
-                case "raw":
-                    return orderBy.column.getSQL();
-                case "sub":
-                    return "(#compileSelect( orderBy.query )#)";
-                default:
-                    return "#wrapColumn( orderBy.column )# #uCase( orderBy.direction )#";
+            if ( orderBy.direction == "raw" ) {
+                return orderBy.column.getSQL();
+            } else if ( orderBy.keyExists( "query" ) ) {
+                return "(#compileSelect( orderBy.query )#) #uCase( orderBy.direction )#";
+            } else {
+                return "#wrapColumn( orderBy.column )# #uCase( orderBy.direction )#";
             }
         } );
 

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -114,13 +114,12 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         }
 
         var orderBys = orders.map( function( orderBy ) {
-            switch ( orderBy.direction ) {
-                case "raw":
-                    return orderBy.column.getSQL();
-                case "sub":
-                    return "(#compileSelect( orderBy.query )#)";
-                default:
-                    return "#wrapColumn( orderBy.column )# #uCase( orderBy.direction )#";
+            if ( orderBy.direction == "raw" ) {
+                return orderBy.column.getSQL();
+            } else if ( orderBy.keyExists( "query" ) ) {
+                return "(#compileSelect( orderBy.query )#) #uCase( orderBy.direction )#";
+            } else {
+                return "#wrapColumn( orderBy.column )# #uCase( orderBy.direction )#";
             }
         } );
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -242,10 +242,7 @@ component extends="testbox.system.BaseSpec" {
                                     .where(
                                         "createdDate",
                                         ">=",
-                                        {
-                                            value = "01/01/2019",
-                                            cfsqltype = "CF_SQL_TIMESTAMP"
-                                        }
+                                        { value: "01/01/2019", cfsqltype: "CF_SQL_TIMESTAMP" }
                                     );
                             }, basicWhereWithQueryParamStruct() );
                         } );
@@ -513,8 +510,8 @@ component extends="testbox.system.BaseSpec" {
                                     .from( "users" )
                                     .whereBetween(
                                         "createdDate",
-                                        { value = "1/1/2019", cfsqltype = "CF_SQL_TIMESTAMP" },
-                                        { value = "12/31/2019", cfsqltype = "CF_SQL_TIMESTAMP" }
+                                        { value: "1/1/2019", cfsqltype: "CF_SQL_TIMESTAMP" },
+                                        { value: "12/31/2019", cfsqltype: "CF_SQL_TIMESTAMP" }
                                     );
                             }, whereBetweenWithQueryParamStructs() );
                         } );
@@ -607,7 +604,9 @@ component extends="testbox.system.BaseSpec" {
 
                         it( "can add where in statements from an array", function() {
                             testCase( function( builder ) {
-                                builder.from( "users" ).whereIn( "id", [ 1, { value: 2, cfsqltype: "CF_SQL_INTEGER" }, 3 ] );
+                                builder
+                                    .from( "users" )
+                                    .whereIn( "id", [ 1, { value: 2, cfsqltype: "CF_SQL_INTEGER" }, 3 ] );
                             }, whereInArrayOfQueryParamStructs() );
                         } );
 
@@ -1171,9 +1170,21 @@ component extends="testbox.system.BaseSpec" {
                         }, orderBy() );
                     } );
 
+                    it( "can add a simple order by using the asc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder.from( "users" ).orderByAsc( "email" );
+                        }, orderBy() );
+                    } );
+
                     it( "can order in descending order", function() {
                         testCase( function( builder ) {
                             builder.from( "users" ).orderBy( "email", "desc" );
+                        }, orderByDesc() );
+                    } );
+
+                    it( "can order in descending order using the desc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder.from( "users" ).orderByDesc( "email" );
                         }, orderByDesc() );
                     } );
 
@@ -1210,6 +1221,42 @@ component extends="testbox.system.BaseSpec" {
                         }, orderBySubselect() );
                     } );
 
+                    it( "can order by a subselect using the asc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderByAsc( function( q ) {
+                                    q.selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" );
+                                } );
+                        }, orderBySubselect() );
+                    } );
+
+                    it( "can order by a subselect descending", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderBy( function( q ) {
+                                    q.selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" );
+                                }, "desc" );
+                        }, orderBySubselectDescending() );
+                    } );
+
+                    it( "can order by a subselect descending using the desc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderByDesc( function( q ) {
+                                    q.selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" );
+                                } );
+                        }, orderBySubselectDescending() );
+                    } );
+
                     it( "can order by a builder instance", function() {
                         testCase( function( builder ) {
                             builder
@@ -1222,6 +1269,49 @@ component extends="testbox.system.BaseSpec" {
                                         .whereColumn( "users.id", "logins.user_id" )
                                 );
                         }, orderByBuilderInstance() );
+                    } );
+
+                    it( "can order by a builder instance using the asc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderByAsc(
+                                    builder
+                                        .newQuery()
+                                        .selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" )
+                                );
+                        }, orderByBuilderInstance() );
+                    } );
+
+                    it( "can order by a builder instance descending", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderBy(
+                                    builder
+                                        .newQuery()
+                                        .selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" ),
+                                    "desc"
+                                );
+                        }, orderByBuilderInstanceDescending() );
+                    } );
+
+                    it( "can order by a builder instance descending using the desc shortcut method", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .orderByDesc(
+                                    builder
+                                        .newQuery()
+                                        .selectRaw( "MAX(created_date)" )
+                                        .from( "logins" )
+                                        .whereColumn( "users.id", "logins.user_id" )
+                                );
+                        }, orderByBuilderInstanceDescending() );
                     } );
 
                     describe( "can accept an array for the column argument", function() {

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -184,7 +184,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function whereBetweenWithQueryParamStructs() {
-        return { sql: "SELECT * FROM `users` WHERE `createdDate` BETWEEN ? AND ?", bindings: [ "1/1/2019", "12/31/2019" ] };
+        return {
+            sql: "SELECT * FROM `users` WHERE `createdDate` BETWEEN ? AND ?",
+            bindings: [ "1/1/2019", "12/31/2019" ]
+        };
     }
 
     function whereNotBetween() {
@@ -660,11 +663,19 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function orderBySubselect() {
-        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`)";
+        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`) ASC";
+    }
+
+    function orderBySubselectDescending() {
+        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`) DESC";
     }
 
     function orderByBuilderInstance() {
-        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`)";
+        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`) ASC";
+    }
+
+    function orderByBuilderInstanceDescending() {
+        return "SELECT * FROM `users` ORDER BY (SELECT MAX(created_date) FROM `logins` WHERE `users`.`id` = `logins`.`user_id`) DESC";
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -187,7 +187,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function whereBetweenWithQueryParamStructs() {
-        return { sql: "SELECT * FROM ""USERS"" WHERE ""CREATEDDATE"" BETWEEN ? AND ?", bindings: [ "1/1/2019", "12/31/2019" ] };
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""CREATEDDATE"" BETWEEN ? AND ?",
+            bindings: [ "1/1/2019", "12/31/2019" ]
+        };
     }
 
     function whereNotBetween() {
@@ -675,11 +678,19 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function orderBySubselect() {
-        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"")";
+        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"") ASC";
+    }
+
+    function orderBySubselectDescending() {
+        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"") DESC";
     }
 
     function orderByBuilderInstance() {
-        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"")";
+        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"") ASC";
+    }
+
+    function orderByBuilderInstanceDescending() {
+        return "SELECT * FROM ""USERS"" ORDER BY (SELECT MAX(created_date) FROM ""LOGINS"" WHERE ""USERS"".""ID"" = ""LOGINS"".""USER_ID"") DESC";
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -187,7 +187,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function whereBetweenWithQueryParamStructs() {
-        return { sql: "SELECT * FROM ""users"" WHERE ""createdDate"" BETWEEN ? AND ?", bindings: [ "1/1/2019", "12/31/2019" ] };
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""createdDate"" BETWEEN ? AND ?",
+            bindings: [ "1/1/2019", "12/31/2019" ]
+        };
     }
 
     function whereNotBetween() {
@@ -675,11 +678,19 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function orderBySubselect() {
-        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"")";
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") ASC";
+    }
+
+    function orderBySubselectDescending() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") DESC";
     }
 
     function orderByBuilderInstance() {
-        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"")";
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") ASC";
+    }
+
+    function orderByBuilderInstanceDescending() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") DESC";
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -184,7 +184,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function whereBetweenWithQueryParamStructs() {
-        return { sql: "SELECT * FROM [users] WHERE [createdDate] BETWEEN ? AND ?", bindings: [ "1/1/2019", "12/31/2019" ] };
+        return {
+            sql: "SELECT * FROM [users] WHERE [createdDate] BETWEEN ? AND ?",
+            bindings: [ "1/1/2019", "12/31/2019" ]
+        };
     }
 
     function whereNotBetween() {
@@ -663,11 +666,19 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function orderBySubselect() {
-        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id])";
+        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id]) ASC";
+    }
+
+    function orderBySubselectDescending() {
+        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id]) DESC";
     }
 
     function orderByBuilderInstance() {
-        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id])";
+        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id]) ASC";
+    }
+
+    function orderByBuilderInstanceDescending() {
+        return "SELECT * FROM [users] ORDER BY (SELECT MAX(created_date) FROM [logins] WHERE [users].[id] = [logins].[user_id]) DESC";
     }
 
     private function getBuilder() {


### PR DESCRIPTION
You can now use two shortcut methods: `orderByAsc` and `orderByDesc`.
Additionally, `orderBySub` or using `orderBy` with a closure or
builder instance will respect the direction argument.
This also introduces a new private method, `orderBySingle`, which can be
overridden in Quick to provide relationship ordering.