### PR TITLE
Add support for MONEY and SMALLMONEY data types

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1251,6 +1251,14 @@ component displayname="Grammar" accessors="true" singleton {
         return "TEXT";
     }
 
+    function typeMoney( column ) {
+        return typeInteger( column );
+    }
+
+    function typeSmallMoney( column ) {
+        return typeInteger( column );
+    }
+
     function typeUnicodeLongText( column ) {
         return "TEXT";
     }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -391,6 +391,14 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "CLOB";
     }
 
+    function typeMoney( column ) {
+        return "NUMBER(19, 4)";
+    }
+
+    function typeSmallMoney( column ) {
+        return "NUMBER(10, 4)";
+    }
+
     function typePoint( column ) {
         return "SDO_GEOMETRY";
     }

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -284,6 +284,14 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "INTEGER";
     }
 
+    function typeMoney( column ) {
+        return "MONEY";
+    }
+
+    function typeSmallMoney( column ) {
+        return typeMoney( column );
+    }
+
     function typePoint( column ) {
         return formatPostGisType( "point" );
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -423,6 +423,14 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "VARCHAR(MAX)";
     }
 
+    function typeMoney( column ) {
+        return "MONEY";
+    }
+
+    function typeSmallMoney( column ) {
+        return "SMALLMONEY";
+    }
+
     function typeUnicodeMediumText( column ) {
         return "NVARCHAR(MAX)";
     }

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -143,6 +143,16 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
+    function money( name ) {
+        arguments.type = "money";
+        return appendColumn( argumentCollection = arguments );
+    }
+
+    function smallMoney( name ) {
+        arguments.type = "smallMoney";
+        return appendColumn( argumentCollection = arguments );
+    }
+
     function morphs( name ) {
         unsignedInteger( "#name#_id" );
         string( "#name#_type" );

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -456,6 +456,32 @@ component extends="testbox.system.BaseSpec" {
                     }, mediumText() );
                 } );
 
+                it( "money", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "transactions",
+                            function( table ) {
+                                table.money( "amount" );
+                            },
+                            {},
+                            false
+                        );
+                    }, money() );
+                } );
+
+                it( "smallMoney", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "transactions",
+                            function( table ) {
+                                table.smallMoney( "amount" );
+                            },
+                            {},
+                            false
+                        );
+                    }, smallMoney() );
+                } );
+
                 it( "morphs", function() {
                     testCase( function( schema ) {
                         return schema.create(

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -144,6 +144,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
     }
 
+    function money() {
+        return [ "CREATE TABLE `transactions` (`amount` INTEGER NOT NULL)" ];
+    }
+
+    function smallMoney() {
+        return [ "CREATE TABLE `transactions` (`amount` INTEGER NOT NULL)" ];
+    }
+
     function morphs() {
         return [
             "CREATE TABLE `tags` (`taggable_id` INTEGER UNSIGNED NOT NULL, `taggable_type` VARCHAR(255) NOT NULL, INDEX `taggable_index` (`taggable_id`, `taggable_type`))"

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -154,6 +154,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""POSTS"" (""BODY"" CLOB NOT NULL)" ];
     }
 
+    function money() {
+        return [ "CREATE TABLE ""TRANSACTIONS"" (""AMOUNT"" NUMBER(19, 4) NOT NULL)" ];
+    }
+    
+    function smallMoney() {
+        return [ "CREATE TABLE ""TRANSACTIONS"" (""AMOUNT"" NUMBER(10, 4) NOT NULL)" ];
+    }
+
     function morphs() {
         return [
             "CREATE TABLE ""TAGS"" (""TAGGABLE_ID"" NUMBER(10, 0) NOT NULL, ""TAGGABLE_TYPE"" VARCHAR2(255) NOT NULL)",

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -157,7 +157,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     function money() {
         return [ "CREATE TABLE ""TRANSACTIONS"" (""AMOUNT"" NUMBER(19, 4) NOT NULL)" ];
     }
-    
+
     function smallMoney() {
         return [ "CREATE TABLE ""TRANSACTIONS"" (""AMOUNT"" NUMBER(10, 4) NOT NULL)" ];
     }

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -141,6 +141,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
     }
 
+    function money() {
+        return [ "CREATE TABLE ""transactions"" (""amount"" MONEY NOT NULL)" ];
+    }
+
+    function smallMoney() {
+        return [ "CREATE TABLE ""transactions"" (""amount"" MONEY NOT NULL)" ];
+    }
+
     function morphs() {
         return [
             "CREATE TABLE ""tags"" (""taggable_id"" INTEGER NOT NULL, ""taggable_type"" VARCHAR(255) NOT NULL)",

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -144,6 +144,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE [posts] ([body] NVARCHAR(MAX) NOT NULL)" ];
     }
 
+    function money() {
+        return [ "CREATE TABLE [transactions] ([amount] MONEY NOT NULL)" ];
+    }
+
+    function smallMoney() {
+        return [ "CREATE TABLE [transactions] ([amount] SMALLMONEY NOT NULL)" ];
+    }
+
     function morphs() {
         return [
             "CREATE TABLE [tags] ([taggable_id] INTEGER NOT NULL, [taggable_type] VARCHAR(255) NOT NULL, INDEX [taggable_index] ([taggable_id], [taggable_type]))"


### PR DESCRIPTION
Add typeMoney and typeSmallMoney
Add tests
Note: Postgres test spec is currently failing due to the ENUM data type, which was caused or addressed by this PR