### PR TITLE
Added options structure to count() method call

### DIFF
--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2028,7 +2028,7 @@ component displayname="QueryBuilder" accessors="true" {
      * @return  PaginationCollector
      */
     public any function paginate( numeric page = 1, numeric maxRows = 25, struct options = {} ) {
-        var totalRecords = count();
+        var totalRecords = count( options = options );
         var results = forPage( page, maxRows ).get( options = options );
         return getPaginationCollector().generateWithResults(
             totalRecords = totalRecords,


### PR DESCRIPTION
The paginage() method calls count() but does not pass along the options argument which will throw an error if the user needs to specify custom query options like "datasource".