### PR TITLE
Update QueryUtils.cfc

### DIFF
--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -225,16 +225,17 @@ component displayname="QueryUtils" accessors="true" {
 
     private boolean function checkIsActuallyNumeric( required any value ) {
         return isNull( arguments.value ) || (
-        isSimpleValue( arguments.value ) && arrayContainsNoCase(
-            [
-                "CFDouble",
-                "Integer",
-                "Double",
-                "Float",
-                "Long",
-                "Short"
-            ],
-            listLast( getMetadata( arguments.value ), '. ' ) )
+            isSimpleValue( arguments.value ) && arrayContainsNoCase(
+                [
+                    "CFDouble",
+                    "Integer",
+                    "Double",
+                    "Float",
+                    "Long",
+                    "Short"
+                ],
+                listLast( getMetadata( arguments.value ), ". " )
+            )
         );
     }
 

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -224,8 +224,8 @@ component displayname="QueryUtils" accessors="true" {
     }
 
     private boolean function checkIsActuallyNumeric( required any value ) {
-        return isNull( arguments.value ) ||
-        arrayContainsNoCase(
+        return isNull( arguments.value ) || (
+        isSimpleValue( arguments.value ) && arrayContainsNoCase(
             [
                 "CFDouble",
                 "Integer",
@@ -234,7 +234,7 @@ component displayname="QueryUtils" accessors="true" {
                 "Long",
                 "Short"
             ],
-            value.getClass().getSimpleName()
+            listLast( getMetadata( arguments.value ), '. ' ) )
         );
     }
 


### PR DESCRIPTION
Replaced the getClass().getSimpleName() with getMetadata() to bypass the java security sandbox if secure profile is enabled.