### PR TITLE
Use wrapTable() for all subqueries and implement Oracle " " table alias operator

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -784,7 +784,12 @@ component displayname="Grammar" accessors="true" singleton {
         var alias = "";
         // Quick check to see if we should bother to use a regex to look for a table alias
         if ( table.find( " " ) ) {
-            var matches = reFindNoCase( "(.*?)(?:\s(?:AS\s){0,1})([^\)\s]+)$", table, 1, true );
+            var matches = reFindNoCase(
+                "(.*?)(?:\s(?:AS\s){0,1})([^\)\s]+)$",
+                table,
+                1,
+                true
+            );
             if ( matches.pos.len() >= 3 ) {
                 alias = mid( table, matches.pos[ 3 ], matches.len[ 3 ] );
                 table = mid( table, matches.pos[ 2 ], matches.len[ 2 ] );

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -807,7 +807,10 @@ component displayname="Grammar" accessors="true" singleton {
                 } )
                 .toList( "." );
         }
-        return alias == "" ? table : table & getTableAliasOperator() & wrapAlias( getTablePrefix() & alias );
+        if ( !alias.len() ) {
+            return table;
+        }
+        return table & getTableAliasOperator() & wrapAlias( getTablePrefix() & alias );
     }
 
     /**
@@ -848,7 +851,10 @@ component displayname="Grammar" accessors="true" singleton {
             .listToArray( "." )
             .map( wrapValue )
             .toList( "." );
-        return alias == "" ? arguments.column : arguments.column & " AS " & wrapValue( alias );
+        if ( !alias.len() ) {
+            return arguments.column;
+        }
+        return arguments.column & " AS " & wrapValue( alias );
     }
 
     /**

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -1,6 +1,21 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
     /**
+     * Creates a new Oracle Query Grammar.
+     *
+     * @utils A collection of query utilities. Default: qb.models.Query.QueryUtils
+     *
+     * @return qb.models.Grammars.OracleGrammar
+     */
+    public OracleGrammar function init( qb.models.Query.QueryUtils utils ) {
+        super.init( argumentsCollection = arguments );
+
+        variables.tableAliasOperator = " ";
+
+        return this;
+    }
+
+    /**
      * Runs a query through `queryExecute`.
      * This function exists so that platform-specific grammars can override it if needed.
      *
@@ -152,7 +167,12 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
             return column.getSql();
         }
 
-        if ( isInstanceOf( column, "qb.models.Schema.TableIndex" ) ) {
+        try {
+            if ( !column.isColumn() ) {
+                throw( message = "Not a Column" );
+            }
+        } catch ( any e ) {
+            // exception happens when isColumn returns false or is not a method on the column object
             throw(
                 type = "InvalidColumn",
                 message = "Recieved a TableIndex instead of a Column when trying to create a Column.",
@@ -160,6 +180,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
             );
         }
 
+        // Oracle: Default value must come before column constraints
         return arrayToList(
             arrayFilter(
                 [

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -342,7 +342,7 @@ component displayname="QueryBuilder" accessors="true" {
             callback( arguments.query );
         }
         return selectRaw(
-            "( #arguments.query.toSQL()# ) AS #getGrammar().wrapAlias( arguments.alias )#",
+            getGrammar().wrapTable( "(#arguments.query.toSQL()#) AS #arguments.alias#" ),
             arguments.query.getBindings()
         );
     }
@@ -474,7 +474,7 @@ component displayname="QueryBuilder" accessors="true" {
         mergeBindings( arguments.input );
 
         // generate the derived table SQL
-        return this.fromRaw( "(#arguments.input.toSQL()#) AS #getGrammar().wrapAlias( arguments.alias )#" );
+        return this.fromRaw( getGrammar().wrapTable( "(#arguments.input.toSQL()#) AS #arguments.alias#" ) );
     }
 
     /*******************************************************************************\
@@ -777,7 +777,9 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         // create the table reference
-        arguments.table = "(#arguments.input.toSQL()#) AS #getGrammar().wrapAlias( arguments.alias )#";
+        arguments.table = getGrammar().wrapTable( "(#arguments.input.toSQL()#) AS #arguments.alias#" );
+
+
 
         // merge bindings
         mergeBindings( arguments.input );
@@ -867,7 +869,7 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         // create the table reference
-        var table = raw( "(#arguments.input.toSQL()#) AS #getGrammar().wrapAlias( arguments.alias )#" );
+        var table = raw( getGrammar().wrapTable( "(#arguments.input.toSQL()#) AS #arguments.alias#" ) );
 
         // merge bindings
         mergeBindings( arguments.input );

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -121,6 +121,31 @@ component displayname="QueryUtils" accessors="true" {
     }
 
     /**
+     * Returns true if a value is a subquery.
+     *
+     * @value The value to check if it is a subquery
+     *
+     * @return boolean
+     */
+    public boolean function isSubQuery( required any value ) {
+        // Includes quick check for a "(" to avoid the regex to look for the subquery pattern if possible
+        return isSimpleValue( arguments.value ) &&
+        arguments.value.find( "(" ) &&
+        arguments.value.reFindNoCase( "^\s*\(.+\)(\s|\sAS\s){0,1}[^\(\s]*\s*$" );
+    }
+
+    /**
+     * Returns true if a value is not a subquery.
+     *
+     * @value The value to check if it is a subquery
+     *
+     * @return boolean
+     */
+    public boolean function isNotSubQuery( required any value ) {
+        return !isSubQuery( value );
+    }
+
+    /**
      * Converts a query object to an array of structs.
      *
      * @q The query to convert.

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -56,16 +56,16 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function subSelect() {
-        return "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id` ) AS `latestUpdatedDate` FROM `users`";
+        return "SELECT `name`, (SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id`) AS `latestUpdatedDate` FROM `users`";
     }
 
     function subSelectQueryObject() {
-        return "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id` ) AS `latestUpdatedDate` FROM `users`";
+        return "SELECT `name`, (SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = `users`.`id`) AS `latestUpdatedDate` FROM `users`";
     }
 
     function subSelectWithBindings() {
         return {
-            sql: "SELECT `name`, ( SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = ? ) AS `latestUpdatedDate` FROM `users`",
+            sql: "SELECT `name`, (SELECT MAX(updated_date) FROM `posts` WHERE `posts`.`user_id` = ?) AS `latestUpdatedDate` FROM `users`",
             bindings: [ 1 ]
         };
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -34,7 +34,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function parseColumnAliasInWhereSubselect() {
         return {
-            "sql": "SELECT ""U"".*, ""USER_ROLES"".""ROLEID"", ""ROLES"".""ROLECODE"" FROM ""USERS"" AS ""U"" INNER JOIN ""USER_ROLES"" ON ""USER_ROLES"".""USERID"" = ""U"".""USERID"" LEFT JOIN ""ROLES"" ON ""USER_ROLES"".""ROLEID"" = ""ROLES"".""ROLEID"" WHERE ""USER_ROLES"".""ROLEID"" = (SELECT ""ROLEID"" FROM ""ROLES"" WHERE ""ROLECODE"" = ?)",
+            "sql": "SELECT ""U"".*, ""USER_ROLES"".""ROLEID"", ""ROLES"".""ROLECODE"" FROM ""USERS"" ""U"" INNER JOIN ""USER_ROLES"" ON ""USER_ROLES"".""USERID"" = ""U"".""USERID"" LEFT JOIN ""ROLES"" ON ""USER_ROLES"".""ROLEID"" = ""ROLES"".""ROLEID"" WHERE ""USER_ROLES"".""ROLEID"" = (SELECT ""ROLEID"" FROM ""ROLES"" WHERE ""ROLECODE"" = ?)",
             "bindings": [ "SYSADMIN" ]
         };
     }
@@ -56,16 +56,16 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function subSelect() {
-        return "SELECT ""NAME"", ( SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ""USERS"".""ID"" ) AS ""LATESTUPDATEDDATE"" FROM ""USERS""";
+        return "SELECT ""NAME"", (SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ""USERS"".""ID"") ""LATESTUPDATEDDATE"" FROM ""USERS""";
     }
 
     function subSelectQueryObject() {
-        return "SELECT ""NAME"", ( SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ""USERS"".""ID"" ) AS ""LATESTUPDATEDDATE"" FROM ""USERS""";
+        return "SELECT ""NAME"", (SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ""USERS"".""ID"") ""LATESTUPDATEDDATE"" FROM ""USERS""";
     }
 
     function subSelectWithBindings() {
         return {
-            sql: "SELECT ""NAME"", ( SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ? ) AS ""LATESTUPDATEDDATE"" FROM ""USERS""",
+            sql: "SELECT ""NAME"", (SELECT MAX(updated_date) FROM ""POSTS"" WHERE ""POSTS"".""USER_ID"" = ?) ""LATESTUPDATEDDATE"" FROM ""USERS""",
             bindings: [ 1 ]
         };
     }
@@ -80,7 +80,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function fromDerivedTable() {
         return {
-            sql: "SELECT * FROM (SELECT ""ID"", ""NAME"" FROM ""USERS"" WHERE ""AGE"" >= ?) AS ""U""",
+            sql: "SELECT * FROM (SELECT ""ID"", ""NAME"" FROM ""USERS"" WHERE ""AGE"" >= ?) ""U""",
             bindings: [ 21 ]
         };
     }
@@ -94,7 +94,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function tablePrefixWithAlias() {
-        return "SELECT * FROM ""PREFIX_USERS"" AS ""PREFIX_PEOPLE""";
+        return "SELECT * FROM ""PREFIX_USERS"" ""PREFIX_PEOPLE""";
     }
 
     function columnAliasWithAs() {
@@ -106,11 +106,11 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function tableAliasWithAs() {
-        return "SELECT * FROM ""USERS"" AS ""PEOPLE""";
+        return "SELECT * FROM ""USERS"" ""PEOPLE""";
     }
 
     function tableAliasWithoutAs() {
-        return "SELECT * FROM ""USERS"" AS ""PEOPLE""";
+        return "SELECT * FROM ""USERS"" ""PEOPLE""";
     }
 
     function basicWhere() {
@@ -267,7 +267,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function multipleJoins() {
-        return "SELECT * FROM ""USERS"" INNER JOIN ""CONTACTS"" ON ""USERS"".""ID"" = ""CONTACTS"".""ID"" INNER JOIN ""ADDRESSES"" AS ""A"" ON ""A"".""CONTACT_ID"" = ""CONTACTS"".""ID""";
+        return "SELECT * FROM ""USERS"" INNER JOIN ""CONTACTS"" ON ""USERS"".""ID"" = ""CONTACTS"".""ID"" INNER JOIN ""ADDRESSES"" ""A"" ON ""A"".""CONTACT_ID"" = ""CONTACTS"".""ID""";
     }
 
     function joinWithWhere() {
@@ -358,28 +358,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function joinSub() {
         return {
-            sql: "SELECT * FROM ""USERS"" AS ""U"" INNER JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) AS ""C"" ON ""U"".""ID"" = ""C"".""ID""",
+            sql: "SELECT * FROM ""USERS"" ""U"" INNER JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) ""C"" ON ""U"".""ID"" = ""C"".""ID""",
             bindings: [ 1, 2, 3 ]
         };
     }
 
     function leftJoinSub() {
         return {
-            sql: "SELECT * FROM ""USERS"" AS ""U"" LEFT JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) AS ""C"" ON ""U"".""ID"" = ""C"".""ID""",
+            sql: "SELECT * FROM ""USERS"" ""U"" LEFT JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) ""C"" ON ""U"".""ID"" = ""C"".""ID""",
             bindings: [ 1, 2, 3 ]
         };
     }
 
     function rightJoinSub() {
         return {
-            sql: "SELECT * FROM ""USERS"" AS ""U"" RIGHT JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) AS ""C"" ON ""U"".""ID"" = ""C"".""ID""",
+            sql: "SELECT * FROM ""USERS"" ""U"" RIGHT JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) ""C"" ON ""U"".""ID"" = ""C"".""ID""",
             bindings: [ 1, 2, 3 ]
         };
     }
 
     function crossJoinSub() {
         return {
-            sql: "SELECT * FROM ""USERS"" AS ""U"" CROSS JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) AS ""C""",
+            sql: "SELECT * FROM ""USERS"" ""U"" CROSS JOIN (SELECT ""ID"" FROM ""CONTACTS"" WHERE ""ID"" NOT IN (?, ?, ?)) ""C""",
             bindings: [ 1, 2, 3 ]
         };
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -56,16 +56,16 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function subSelect() {
-        return "SELECT ""name"", ( SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"" ) AS ""latestUpdatedDate"" FROM ""users""";
+        return "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"") AS ""latestUpdatedDate"" FROM ""users""";
     }
 
     function subSelectQueryObject() {
-        return "SELECT ""name"", ( SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"" ) AS ""latestUpdatedDate"" FROM ""users""";
+        return "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"") AS ""latestUpdatedDate"" FROM ""users""";
     }
 
     function subSelectWithBindings() {
         return {
-            sql: "SELECT ""name"", ( SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ? ) AS ""latestUpdatedDate"" FROM ""users""",
+            sql: "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ?) AS ""latestUpdatedDate"" FROM ""users""",
             bindings: [ 1 ]
         };
     }

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -56,16 +56,16 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function subSelect() {
-        return "SELECT [name], ( SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = [users].[id] ) AS [latestUpdatedDate] FROM [users]";
+        return "SELECT [name], (SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = [users].[id]) AS [latestUpdatedDate] FROM [users]";
     }
 
     function subSelectQueryObject() {
-        return "SELECT [name], ( SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = [users].[id] ) AS [latestUpdatedDate] FROM [users]";
+        return "SELECT [name], (SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = [users].[id]) AS [latestUpdatedDate] FROM [users]";
     }
 
     function subSelectWithBindings() {
         return {
-            sql: "SELECT [name], ( SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = ? ) AS [latestUpdatedDate] FROM [users]",
+            sql: "SELECT [name], (SELECT MAX(updated_date) FROM [posts] WHERE [posts].[user_id] = ?) AS [latestUpdatedDate] FROM [users]",
             bindings: [ 1 ]
         };
     }


### PR DESCRIPTION
Added TableAliasOperator property to BaseGrammer.cfc.
Changed all QueryBuilder methods that return subqueries to call wrapTable().
Fixed a bug in wrapTable() that caused the table prefix to not be applied unless the table included owner/schema prefix ("myschema.mytable") and added a bypass to keep tablePrefix from being inserted into the subquery which was deforming the subquery.
Updated test suites as needed.
Did some other tests to see performance impact. (See attached).
[wrapTable performance tests.txt](https://github.com/coldbox-modules/qb/files/4950292/wrapTable.performance.tests.txt)
