### PR TITLE
Fix(BaseGrammer): Allow spaces in table aliases.

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -787,7 +787,7 @@ component displayname="Grammar" accessors="true" singleton {
         // Quick check to see if we should bother to use a regex to look for a table alias
         if ( table.find( " " ) ) {
             var matches = reFindNoCase(
-                "(.*?)(?:\s(?:AS\s){0,1})([^\)\s]+)$",
+                "(.*?)(?:\s(?:AS\s){0,1})([^\)]+)$",
                 table,
                 1,
                 true

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -782,6 +782,8 @@ component displayname="Grammar" accessors="true" singleton {
         }
 
         var alias = "";
+        // trim table to prevent incorrect " " matching
+        arguments.table = trim( arguments.table );
         // Quick check to see if we should bother to use a regex to look for a table alias
         if ( table.find( " " ) ) {
             var matches = reFindNoCase(


### PR DESCRIPTION
Resolves #121.