### PR TITLE
Add a dump command to aid in debugging a query while chaining

### DIFF
--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2938,6 +2938,20 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
+     * Dumps out the query using `writeDump` then returns the query instance for continued chaining.
+     * Accepts all arguments that can be passed to `writeDump` as well as `showBindings` for the `toSQL` call.
+     *
+     * @return qb.models.Query.QueryBuilder
+     */
+    public QueryBuilder function dump() {
+        param arguments.showBindings = false;
+        arguments.var = toSQL( showBindings = arguments.showBindings );
+        structDelete( arguments, "showBindings" );
+        writeDump( argumentCollection = arguments );
+        return this;
+    }
+
+    /**
      * Sets the return format for the query.
      * The return format can be a simple string like "query" to return queries or "array" to return an array of structs.
      * Alternative, the return format can be a closure.  The closure is passed the query as the only argument.  The result of the closure is returned as the result of the query.

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2943,11 +2943,34 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @return qb.models.Query.QueryBuilder
      */
-    public QueryBuilder function dump() {
-        param arguments.showBindings = false;
-        arguments.var = toSQL( showBindings = arguments.showBindings );
-        structDelete( arguments, "showBindings" );
-        writeDump( argumentCollection = arguments );
+    public QueryBuilder function dump(
+        boolean showBindings = false,
+        string output = "browser",
+        string format = "text",
+        boolean abort = false,
+        string label = "",
+        boolean metainfo = false,
+        numeric top = 9999,
+        string show = "",
+        string hide = "",
+        numeric keys = 9999,
+        boolean expand = true,
+        boolean showUDFs = true
+    ) {
+        writeDump(
+            var = toSQL( showBindings = arguments.showBindings ),
+            output = arguments.output,
+            format = arguments.format,
+            abort = arguments.abort,
+            label = arguments.label,
+            metainfo = arguments.metainfo,
+            top = arguments.top,
+            show = arguments.show,
+            hide = arguments.hide,
+            keys = arguments.keys,
+            expand = arguments.expand,
+            showUDFs = arguments.showUDFs
+        );
         return this;
     }
 


### PR DESCRIPTION
Calling dump will forward on the arguments to `writeDump` and output the current query using `toSQL`. The QueryBuilder instance is returned so you can continue chaining.  `showBindings` can also be passed to inline the bindings to the query