### PR TITLE
set correct mysql data type when using longText schema builder method

### DIFF
--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -139,6 +139,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "NCHAR(#column.getLength()#)";
     }
 
+    function typeLongText( column ) {
+        return "LONGTEXT";
+    }    
+
     function typeLineString( column ) {
         return "LINESTRING";
     }

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -119,7 +119,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function longText() {
-        return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
+        return [ "CREATE TABLE `posts` (`body` LONGTEXT NOT NULL)" ];
     }
 
     function UnicodeLongText() {


### PR DESCRIPTION
When using attempting to create a longtext field using the `longtext()` method, qb will use the incorrect `text` data type. This causes an issue as mysql text data types only support 64kb