### PR TITLE
Add support for mediumtext & longtext types

### DIFF
--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -150,5 +150,13 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     function typePolygon( column ) {
         return "POLYGON";
     }
+    
+    function typeMediumText( column ) {
+        return "MEDIUMTEXT";
+    }
+
+    function typeLongText( column ) {
+        return "LONGTEXT";
+    }
 
 }

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -119,7 +119,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function longText() {
-        return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
+        return [ "CREATE TABLE `posts` (`body` LONGTEXT NOT NULL)" ];
     }
 
     function UnicodeLongText() {
@@ -141,7 +141,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function mediumText() {
-        return [ "CREATE TABLE `posts` (`body` TEXT NOT NULL)" ];
+        return [ "CREATE TABLE `posts` (`body` MEDIUMTEXT NOT NULL)" ];
     }
 
     function money() {


### PR DESCRIPTION
When using schema builder, the `mediumtext` & `longtext` functions previously resulted in the creation of a `TEXT` field. This update adds support to the MySQL grammar for the appropriate column type.