### PR TITLE
feat(Locks): Add locking helpers to qb

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -47,7 +47,8 @@ component displayname="Grammar" accessors="true" singleton {
         "unions",
         "orders",
         "limitValue",
-        "offsetValue"
+        "offsetValue",
+        "lockType"
     ];
 
     /**
@@ -656,6 +657,29 @@ component displayname="Grammar" accessors="true" singleton {
             return "";
         }
         return "OFFSET #offsetValue#";
+    }
+
+    /**
+     * Compiles the lock portion of a sql statement.
+     *
+     * @query The Builder instance.
+     * @lockType The lock type to compile.
+     *
+     * @return string
+     */
+    private string function compileLockType( required query, required string lockType ) {
+        switch ( arguments.lockType ) {
+            case "shared":
+                return "LOCK IN SHARE MODE";
+            case "update":
+                return "FOR UPDATE";
+            case "custom":
+                return arguments.query.getLockValue();
+            case "none":
+            case "nolock":
+            default:
+                return "";
+        }
     }
 
     /**

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -1,6 +1,29 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
     /**
+     * Compiles the lock portion of a sql statement.
+     *
+     * @query The Builder instance.
+     * @lockType The lock type to compile.
+     *
+     * @return string
+     */
+    private string function compileLockType( required query, required string lockType ) {
+        switch ( arguments.lockType ) {
+            case "shared":
+                return "FOR SHARE";
+            case "update":
+                return "FOR UPDATE";
+            case "custom":
+                return arguments.query.getLockValue();
+            case "none":
+            case "nolock":
+            default:
+                return "";
+        }
+    }
+
+    /**
      * Compile a Builder's query into an insert string.
      *
      * @query The Builder instance.

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -13,6 +13,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         "aggregate",
         "columns",
         "from",
+        "lockType",
         "joins",
         "wheres",
         "groups",
@@ -99,6 +100,30 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
             select &= "TOP (#query.getLimitValue()#) ";
         }
         return select & columns.map( wrapColumn ).toList( ", " );
+    }
+
+    /**
+     * Compiles the lock portion of a sql statement.
+     *
+     * @query The Builder instance.
+     * @lockType The lock type to compile.
+     *
+     * @return string
+     */
+    private string function compileLockType( required query, required string lockType ) {
+        switch ( arguments.lockType ) {
+            case "nolock":
+                return "WITH (NOLOCK)";
+            case "shared":
+                return "WITH (ROWLOCK,HOLDLOCK)";
+            case "update":
+                return "WITH (ROWLOCK,UPDLOCK,HOLDLOCK)";
+            case "custom":
+                return arguments.query.getLockValue();
+            case "none":
+            default:
+                return "";
+        }
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -96,6 +96,17 @@ component displayname="QueryBuilder" accessors="true" {
     property name="from" type="string";
 
     /**
+     * The type of lock for the table. Default: `none`
+     * Expected values are `none`, `nolock`, `shared`, `update`, and `custom`.
+     */
+    property name="lockType" type="string";
+
+    /**
+     * The value for a custom lock.
+     */
+    property name="lockValue" type="string";
+
+    /**
      * An array of JOIN statements.
      * @default []
      */
@@ -294,6 +305,8 @@ component displayname="QueryBuilder" accessors="true" {
         variables.unions = [];
         variables.returning = [];
         variables.updates = {};
+        variables.lockType = "none";
+        variables.lockValue = "";
     }
 
     /**********************************************************************************************\
@@ -529,6 +542,40 @@ component displayname="QueryBuilder" accessors="true" {
 
         // generate the derived table SQL
         return this.fromRaw( getGrammar().wrapTable( "(#arguments.input.toSQL()#) AS #arguments.alias#" ) );
+    }
+
+    /*******************************************************************************\
+    |                               LOCK functions                                  |
+    \*******************************************************************************/
+
+    public QueryBuilder function lock( required string value ) {
+        variables.lockType = "custom";
+        variables.lockValue = arguments.value;
+        return this;
+    }
+
+    public QueryBuilder function noLock() {
+        variables.lockType = "nolock";
+        variables.lockValue = "";
+        return this;
+    }
+
+    public QueryBuilder function sharedLock() {
+        variables.lockType = "shared";
+        variables.lockValue = "";
+        return this;
+    }
+
+    public QueryBuilder function lockForUpdate() {
+        variables.lockType = "update";
+        variables.lockValue = "";
+        return this;
+    }
+
+    public QueryBuilder function clearLock() {
+        variables.lockType = "none";
+        variables.lockValue = "";
+        return this;
     }
 
     /*******************************************************************************\

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -238,6 +238,44 @@ component extends="testbox.system.BaseSpec" {
                     } );
                 } );
 
+                describe( "locking", function() {
+                    it( "can set no lock", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .noLock();
+                        }, noLock() );
+                    } );
+
+                    it( "can set a shared lock", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .sharedLock();
+                        }, sharedLock() );
+                    } );
+
+                    it( "can lock for update", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .lockForUpdate();
+                        }, lockForUpdate() );
+                    } );
+
+                    it( "can pass an arbitrary string to lock", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .lock( "foobar" );
+                        }, lockArbitraryString() );
+                    } );
+                } );
+
                 describe( "using table prefixes", function() {
                     it( "can perform a basic select with a table prefix", function() {
                         testCase( function( builder ) {

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -94,6 +94,22 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM (SELECT `id`, `name` FROM `users` WHERE `age` >= ?) AS `u`", bindings: [ 21 ] };
     }
 
+    function noLock() {
+        return { sql: "SELECT * FROM `users` WHERE `id` = ?", bindings: [ 1 ] };
+    }
+
+    function sharedLock() {
+        return { sql: "SELECT * FROM `users` WHERE `id` = ? LOCK IN SHARE MODE", bindings: [ 1 ] };
+    }
+
+    function lockForUpdate() {
+        return { sql: "SELECT * FROM `users` WHERE `id` = ? FOR UPDATE", bindings: [ 1 ] };
+    }
+
+    function lockArbitraryString() {
+        return { sql: "SELECT * FROM `users` WHERE `id` = ? foobar", bindings: [ 1 ] };
+    }
+
     function table() {
         return "SELECT * FROM `users`";
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -97,6 +97,31 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function noLock() {
+        return { "sql": "SELECT * FROM ""USERS"" WHERE ""ID"" = ?", "bindings": [ 1 ] };
+    }
+
+    function sharedLock() {
+        return {
+            "sql": "LOCK TABLE ""USERS"" IN SHARE MODE NOWAIT; SELECT * FROM ""USERS"" WHERE ""ID"" = ?",
+            "bindings": [ 1 ]
+        };
+    }
+
+    function lockForUpdate() {
+        return {
+            "sql": "LOCK TABLE ""USERS"" IN ROW EXCLUSIVE MODE NOWAIT; SELECT * FROM ""USERS"" WHERE ""ID"" = ?",
+            "bindings": [ 1 ]
+        };
+    }
+
+    function lockArbitraryString() {
+        return {
+            "sql": "LOCK TABLE ""USERS"" IN foobar MODE NOWAIT; SELECT * FROM ""USERS"" WHERE ""ID"" = ?",
+            "bindings": [ 1 ]
+        };
+    }
+
     function table() {
         return "SELECT * FROM ""USERS""";
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -97,6 +97,22 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function noLock() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+
+    function sharedLock() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ? FOR SHARE", "bindings": [ 1 ] };
+    }
+
+    function lockForUpdate() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ? FOR UPDATE", "bindings": [ 1 ] };
+    }
+
+    function lockArbitraryString() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ? foobar", "bindings": [ 1 ] };
+    }
+
     function table() {
         return "SELECT * FROM ""users""";
     }

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -94,6 +94,22 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM (SELECT [id], [name] FROM [users] WHERE [age] >= ?) AS [u]", bindings: [ 21 ] };
     }
 
+    function noLock() {
+        return { "sql": "SELECT * FROM [users] WITH (NOLOCK) WHERE [id] = ?", "bindings": [ 1 ] };
+    }
+
+    function sharedLock() {
+        return { "sql": "SELECT * FROM [users] WITH (ROWLOCK,HOLDLOCK) WHERE [id] = ?", "bindings": [ 1 ] };
+    }
+
+    function lockForUpdate() {
+        return { "sql": "SELECT * FROM [users] WITH (ROWLOCK,UPDLOCK,HOLDLOCK) WHERE [id] = ?", "bindings": [ 1 ] };
+    }
+
+    function lockArbitraryString() {
+        return { "sql": "SELECT * FROM [users] foobar WHERE [id] = ?", "bindings": [ 1 ] };
+    }
+
     function table() {
         return "SELECT * FROM [users]";
     }


### PR DESCRIPTION
Select queries can now add locking text based on the following methods:

1. `noLock()` -> Adds a NO LOCK hint in appropriate grammars.
2. `sharedLock()` -> Adds a lock to prevent updates but allow selects for the selected rows.
3. `lockForUpdate()` -> Adds a lock for updating the selected rows.
4. `lock( required string value )` -> Adds a custom lock text.

Closes #145 