### PR TITLE
feat(SchemaBuilder): Add computed / virtual column support

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -962,6 +962,7 @@ component displayname="Grammar" accessors="true" singleton {
                     wrapColumn( column.getName() ),
                     generateType( column, blueprint ),
                     modifyUnsigned( column ),
+                    generateComputed( column ),
                     generateNullConstraint( column ),
                     generateUniqueConstraint( column, blueprint ),
                     generateAutoIncrement( column, blueprint ),
@@ -986,6 +987,16 @@ component displayname="Grammar" accessors="true" singleton {
 
     function modifyUnsigned( column ) {
         return column.getUnsigned() ? "UNSIGNED" : "";
+    }
+
+    function generateComputed( column ) {
+        if ( column.getComputedType() == "none" ) {
+            return "";
+        }
+
+        return "GENERATED ALWAYS AS (#column.getComputedDefinition()#) " & (
+            column.getComputedType() == "virtual" ? "VIRTUAL" : "STORED"
+        );
     }
 
     function generateAutoIncrement( column, blueprint ) {

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -222,6 +222,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
                     wrapColumn( column.getName() ),
                     generateType( column, blueprint ),
                     modifyUnsigned( column ),
+                    generateComputed( column ),
                     generateAutoIncrement( column, blueprint ),
                     generateDefault( column ),
                     generateNullConstraint( column ),
@@ -332,8 +333,22 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "";
     }
 
+    function generateNullConstraint( column ) {
+        return ( column.getNullable() || column.getComputedType() != "none" ) ? "" : "NOT NULL";
+    }
+
     function modifyUnsigned( column ) {
         return "";
+    }
+
+    function generateComputed( column ) {
+        if ( column.getComputedType() == "none" ) {
+            return "";
+        }
+
+        return "GENERATED ALWAYS AS (#column.getComputedDefinition()#)" & (
+            column.getComputedType() == "virtual" ? " VIRTUAL" : ""
+        );
     }
 
     function generateAutoIncrement( column, blueprint ) {

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -234,8 +234,27 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         );
     }
 
+    function generateType( column, blueprint ) {
+        if ( column.getComputedType() != "none" ) {
+            return "";
+        }
+        return super.generateType( argumentCollection = arguments );
+    }
+
+    function generateNullConstraint( column ) {
+        return ( column.getNullable() || column.getComputedType() != "none" ) ? "" : "NOT NULL";
+    }
+
     function modifyUnsigned( column ) {
         return "";
+    }
+
+    function generateComputed( column ) {
+        if ( column.getComputedType() == "none" ) {
+            return "";
+        }
+
+        return "AS (#column.getComputedDefinition()#)" & ( column.getComputedType() == "virtual" ? "" : " PERSISTED" );
     }
 
     function generateAutoIncrement( column ) {

--- a/models/Schema/Column.cfc
+++ b/models/Schema/Column.cfc
@@ -66,6 +66,16 @@ component accessors="true" {
     property name="values";
 
     /**
+     * The computed column type, if any.  Defaults to `none`.
+     */
+    property name="computedType" default="none";
+
+    /**
+     * The definition of the computed column, if any.
+     */
+    property name="computedDefinition";
+
+    /**
      * Create a new column representation.
      *
      * @blueprint The blueprint object creating this column.
@@ -75,6 +85,8 @@ component accessors="true" {
     function init( blueprint ) {
         setBlueprint( blueprint );
         variables.values = [];
+        variables.computedType = "none";
+        variables.computedDefinition = "";
         return this;
     }
 
@@ -177,6 +189,32 @@ component accessors="true" {
      */
     function withCurrent() {
         setDefault( "CURRENT_TIMESTAMP" );
+        return this;
+    }
+
+    /**
+     * Marks the column as a stored computed column.
+     *
+     * @expression  The SQL used to define the computed column.
+     *
+     * @returns     Column
+     */
+    function storedAs( required string expression ) {
+        variables.computedType = "stored";
+        variables.computedDefinition = arguments.expression;
+        return this;
+    }
+
+    /**
+     * Marks the column as a virtual computed column.
+     *
+     * @expression  The SQL used to define the computed column.
+     *
+     * @returns     Column
+     */
+    function virtualAs( required string expression ) {
+        variables.computedType = "virtual";
+        variables.computedDefinition = arguments.expression;
         return this;
     }
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -157,6 +157,34 @@ component extends="testbox.system.BaseSpec" {
                     }, charWithLength() );
                 } );
 
+                it( "computed (stored)", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "products",
+                            function( table ) {
+                                table.integer( "price" );
+                                table.integer( "tax" ).storedAs( "price * 0.0675" );
+                            },
+                            {},
+                            false
+                        );
+                    }, computedStored() );
+                } );
+
+                it( "computed (virtual)", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "products",
+                            function( table ) {
+                                table.integer( "price" );
+                                table.integer( "tax" ).virtualAs( "price * 0.0675" );
+                            },
+                            {},
+                            false
+                        );
+                    }, computedVirtual() );
+                } );
+
                 it( "date", function() {
                     testCase( function( schema ) {
                         return schema.create(

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -48,6 +48,18 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `classifications` (`abbreviation` NCHAR(3) NOT NULL)" ];
     }
 
+    function computedStored() {
+        return [
+            "CREATE TABLE `products` (`price` INTEGER NOT NULL, `tax` INTEGER GENERATED ALWAYS AS (price * 0.0675) STORED NOT NULL)"
+        ];
+    }
+
+    function computedVirtual() {
+        return [
+            "CREATE TABLE `products` (`price` INTEGER NOT NULL, `tax` INTEGER GENERATED ALWAYS AS (price * 0.0675) VIRTUAL NOT NULL)"
+        ];
+    }
+
     function date() {
         return [ "CREATE TABLE `posts` (`posted_date` DATE NOT NULL)" ];
     }

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -52,6 +52,18 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""CLASSIFICATIONS"" (""ABBREVIATION"" CHAR(3) NOT NULL)" ];
     }
 
+    function computedStored() {
+        return [
+            "CREATE TABLE ""PRODUCTS"" (""PRICE"" NUMBER(10, 0) NOT NULL, ""TAX"" NUMBER(10, 0) GENERATED ALWAYS AS (price * 0.0675))"
+        ];
+    }
+
+    function computedVirtual() {
+        return [
+            "CREATE TABLE ""PRODUCTS"" (""PRICE"" NUMBER(10, 0) NOT NULL, ""TAX"" NUMBER(10, 0) GENERATED ALWAYS AS (price * 0.0675) VIRTUAL)"
+        ];
+    }
+
     function date() {
         return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" DATE NOT NULL)" ];
     }

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -46,6 +46,18 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""classifications"" (""abbreviation"" CHAR(3) NOT NULL)" ];
     }
 
+    function computedStored() {
+        return [
+            "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER NOT NULL GENERATED ALWAYS AS (price * 0.0675) STORED)"
+        ];
+    }
+
+    function computedVirtual() {
+        return [
+            "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER NOT NULL GENERATED ALWAYS AS (price * 0.0675) STORED)"
+        ];
+    }
+
     function date() {
         return [ "CREATE TABLE ""posts"" (""posted_date"" DATE NOT NULL)" ];
     }

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -46,6 +46,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE [classifications] ([abbreviation] NCHAR(3) NOT NULL)" ];
     }
 
+    function computedStored() {
+        return [ "CREATE TABLE [products] ([price] INTEGER NOT NULL, [tax] AS (price * 0.0675) PERSISTED)" ];
+    }
+
+    function computedVirtual() {
+        return [ "CREATE TABLE [products] ([price] INTEGER NOT NULL, [tax] AS (price * 0.0675))" ];
+    }
+
     function date() {
         return [ "CREATE TABLE [posts] ([posted_date] DATE NOT NULL)" ];
     }


### PR DESCRIPTION
Computed columns can be created using a `virtualAs` or `storedAs`
modifier on any column.