### PR TITLE
fix(Aggregates): Correctly return aggregate values

### DIFF
--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3167,7 +3167,7 @@ component displayname="QueryBuilder" accessors="true" {
         var result = callback();
         setAggregate( originalAggregate );
         setOrders( originalOrders );
-        return isNumeric( result ) ? result : 0;
+        return result;
     }
 
     /**

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -556,6 +556,27 @@ component extends="testbox.system.BaseSpec" {
 
                     expect( builder.getAggregate() ).toBeEmpty( "Aggregate should have been cleared after running" );
                 } );
+
+                it( "can return the max date of a table", function() {
+                    var builder = getBuilder();
+                    var expectedMax = now();
+                    var expectedQuery = queryNew( "aggregate", "timestamp", [ { aggregate: expectedMax } ] );
+                    builder
+                        .$( "runQuery" )
+                        .$args( sql = "SELECT MAX(""login_date"") AS ""aggregate"" FROM ""users""", options = {} )
+                        .$results( expectedQuery );
+
+                    var results = builder.from( "users" ).max( "login_date" );
+
+                    expect( results ).toBe( expectedMax );
+
+                    var runQueryLog = builder.$callLog().runQuery;
+                    expect( runQueryLog ).toBeArray();
+                    expect( runQueryLog ).toHaveLength( 1, "runQuery should have been called once" );
+                    expect( runQueryLog[ 1 ] ).toBe( { sql: "SELECT MAX(""login_date"") AS ""aggregate"" FROM ""users""", options: {} } );
+
+                    expect( builder.getAggregate() ).toBeEmpty( "Aggregate should have been cleared after running" );
+                } );
             } );
 
             describe( "min", function() {


### PR DESCRIPTION
For some reason, values that were not numeric were returned as 0.
This broke things like `MAX(date)` calls and has been removed.