### PR TITLE
feat(QueryUtils): Automatically add `scale` to bindings when needed

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -8,14 +8,15 @@ component {
 
     function configure() {
         settings = {
-            defaultGrammar: "AutoDiscover@qb",
-            defaultReturnFormat: "array",
-            preventDuplicateJoins: false,
-            strictDateDetection: false,
-            numericSQLType: "CF_SQL_NUMERIC"
+            "defaultGrammar": "AutoDiscover@qb",
+            "defaultReturnFormat": "array",
+            "preventDuplicateJoins": false,
+            "strictDateDetection": false,
+            "numericSQLType": "CF_SQL_NUMERIC",
+            "autoAddScale": true
         };
 
-        interceptorSettings = { customInterceptionPoints: "preQBExecute,postQBExecute" };
+        interceptorSettings = { "customInterceptionPoints": "preQBExecute,postQBExecute" };
     }
 
     function onLoad() {

--- a/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
@@ -66,6 +66,57 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
                 expect( binding.list ).toBe( false );
                 expect( binding.null ).toBe( false );
             } );
+
+            it( "automatically sets a scale if needed", function() {
+                var binding = utils.extractBinding( { "value": 3.14159, "cfsqltype": "CF_SQL_DECIMAL" } );
+
+                expect( binding ).toBeStruct();
+                expect( binding.value ).toBe( 3.14159 );
+                expect( binding.cfsqltype ).toBe( "CF_SQL_DECIMAL" );
+                expect( binding ).toHaveKey( "scale" );
+                expect( binding.scale ).toBe( 5 );
+                expect( binding.list ).toBe( false );
+                expect( binding.null ).toBe( false );
+            } );
+
+            it( "does not set a scale for integers", function() {
+                var binding = utils.extractBinding( { "value": 3.14159, "cfsqltype": "CF_SQL_INTEGER" } );
+
+                expect( binding ).toBeStruct();
+                expect( binding.value ).toBe( 3.14159 );
+                expect( binding.cfsqltype ).toBe( "CF_SQL_INTEGER" );
+                expect( binding ).notToHaveKey( "scale" );
+                expect( binding.list ).toBe( false );
+                expect( binding.null ).toBe( false );
+            } );
+
+            it( "does not set a scale when autoSetScale is set to false", function() {
+                try {
+                    utils.setAutoAddScale( false );
+                    var binding = utils.extractBinding( { "value": 3.14159, "cfsqltype": "CF_SQL_DECIMAL" } );
+
+                    expect( binding ).toBeStruct();
+                    expect( binding.value ).toBe( 3.14159 );
+                    expect( binding.cfsqltype ).toBe( "CF_SQL_DECIMAL" );
+                    expect( binding ).notToHaveKey( "scale" );
+                    expect( binding.list ).toBe( false );
+                    expect( binding.null ).toBe( false );
+                } finally {
+                    utils.setAutoAddScale( true );
+                }
+            } );
+
+            it( "uses a passed in scale if provided", function() {
+                var binding = utils.extractBinding( { "value": 3.14159, "cfsqltype": "CF_SQL_DECIMAL", "scale": 2 } );
+
+                expect( binding ).toBeStruct();
+                expect( binding.value ).toBe( 3.14159 );
+                expect( binding.cfsqltype ).toBe( "CF_SQL_DECIMAL" );
+                expect( binding ).toHaveKey( "scale" );
+                expect( binding.scale ).toBe( 2 );
+                expect( binding.list ).toBe( false );
+                expect( binding.null ).toBe( false );
+            } );
         } );
 
         describe( "queryToArrayOfStructs()", function() {


### PR DESCRIPTION
Some versions of ACF combined with SQL Server will automatically use a `scale` of 0 when not supplied.  This causes very hard to debug issues since everything looks right from the query side.  To combat this, qb will automatically provide a scale when the incoming argument is 1) one of the numeric sql types that are floating point and 2) a scale is not already provided in the binding.  This feature can be disabled by setting `autoAddScale` to `false` in your `moduleSettings`.