### PR TITLE
Added new property for CTE column parentheses requirement

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -63,6 +63,7 @@ component displayname="Grammar" accessors="true" singleton {
         variables.utils = arguments.utils;
         variables.tablePrefix = "";
         variables.tableAliasOperator = " AS ";
+        variables.cteColumnsRequireParentheses = false;
         // These are overwritten by WireBox, if it exists.
         variables.interceptorService = {
             "processState": function() {
@@ -200,7 +201,7 @@ component displayname="Grammar" accessors="true" singleton {
                 hasRecursion = true;
             }
 
-            return wrapColumn( arguments.commonTable.name ) & ( len( columns ) ? " " & columns : "" ) & " AS (" & sql & ")";
+            return wrapColumn( arguments.commonTable.name ) & ( len( columns ) ? " " & ( variables.cteColumnsRequireParentheses ? "(" : "" ) & columns & ( variables.cteColumnsRequireParentheses ? ")" : "" )  : "" ) & " AS (" & sql & ")";
         } );
 
         /*

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -201,11 +201,7 @@ component displayname="Grammar" accessors="true" singleton {
                 hasRecursion = true;
             }
 
-            return wrapColumn( arguments.commonTable.name ) & (
-                len( columns ) ? " " & ( variables.cteColumnsRequireParentheses ? "(" : "" ) & columns & (
-                    variables.cteColumnsRequireParentheses ? ")" : ""
-                ) : ""
-            ) & " AS (" & sql & ")";
+            return wrapColumn( arguments.commonTable.name ) & ( len( columns ) ? " " & ( variables.cteColumnsRequireParentheses ? "(" : "" ) & columns & ( variables.cteColumnsRequireParentheses ? ")" : "" )  : "" ) & " AS (" & sql & ")";
         } );
 
         /*

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -201,7 +201,11 @@ component displayname="Grammar" accessors="true" singleton {
                 hasRecursion = true;
             }
 
-            return wrapColumn( arguments.commonTable.name ) & ( len( columns ) ? " " & ( variables.cteColumnsRequireParentheses ? "(" : "" ) & columns & ( variables.cteColumnsRequireParentheses ? ")" : "" )  : "" ) & " AS (" & sql & ")";
+            return wrapColumn( arguments.commonTable.name ) & (
+                len( columns ) ? " " & ( variables.cteColumnsRequireParentheses ? "(" : "" ) & columns & (
+                    variables.cteColumnsRequireParentheses ? ")" : ""
+                ) : ""
+            ) & " AS (" & sql & ")";
         } );
 
         /*

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -9,12 +9,12 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
      */
     public PostgresGrammar function init( qb.models.Query.QueryUtils utils ) {
         super.init( argumentCollection = arguments );
-        
+
         variables.cteColumnsRequireParentheses = true;
 
         return this;
     }
-    
+
     /**
      * Compiles the lock portion of a sql statement.
      *

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -1,6 +1,21 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
     /**
+     * Creates a new Postgres Query Grammar.
+     *
+     * @utils A collection of query utilities. Default: qb.models.Query.QueryUtils
+     *
+     * @return qb.models.Grammars.PostgresGrammar
+     */
+    public PostgresGrammar function init( qb.models.Query.QueryUtils utils ) {
+        super.init( argumentCollection = arguments );
+        
+        variables.cteColumnsRequireParentheses = false;
+
+        return this;
+    }
+    
+    /**
      * Compiles the lock portion of a sql statement.
      *
      * @query The Builder instance.

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -9,12 +9,12 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
      */
     public PostgresGrammar function init( qb.models.Query.QueryUtils utils ) {
         super.init( argumentCollection = arguments );
-
+        
         variables.cteColumnsRequireParentheses = true;
 
         return this;
     }
-
+    
     /**
      * Compiles the lock portion of a sql statement.
      *

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -10,7 +10,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     public PostgresGrammar function init( qb.models.Query.QueryUtils utils ) {
         super.init( argumentCollection = arguments );
         
-        variables.cteColumnsRequireParentheses = false;
+        variables.cteColumnsRequireParentheses = true;
 
         return this;
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -35,7 +35,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     public SqlServerGrammar function init( qb.models.Query.QueryUtils utils ) {
         super.init( argumentCollection = arguments );
 
-        variables.cteColumnsRequireParentheses = false;
+        variables.cteColumnsRequireParentheses = true;
 
         return this;
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -24,6 +24,22 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         "limitValue"
     ];
 
+
+    /**
+     * Creates a new SQL Server Query Grammar.
+     *
+     * @utils A collection of query utilities. Default: qb.models.Query.QueryUtils
+     *
+     * @return qb.models.Grammars.SqlServerGrammar
+     */
+    public SqlServerGrammar function init( qb.models.Query.QueryUtils utils ) {
+        super.init( argumentCollection = arguments );
+
+        variables.cteColumnsRequireParentheses = false;
+
+        return this;
+    }
+
     /**
      * Compile a Builder's query into an insert string.
      *

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1832,6 +1832,23 @@ component extends="testbox.system.BaseSpec" {
                         }, commonTableExpressionWithRecursive() );
                     } );
 
+                    it( "properly handles recursive CTEs with included columns", function() {
+                        
+                        testCase( function( builder ) {
+                            builder
+                                .withRecursive( "UsersCTE", function( q ) {
+                                    q.select( [ "users.id AS usersId", "contacts.id AS contactsId" ] )
+                                        .from( "users" )
+                                        .join( "contacts", "users.id", "contacts.id" )
+                                        .where( "users.age", ">", 25 )
+                                    ;
+                                }, [ "usersId", "contactsId" ] )
+                                .from( "UsersCTE" )
+                                .whereNotIn( "user.id", [ 1, 2 ] )
+                            ;
+                        }, commonTableExpressionWithRecursiveWithColumns() );
+                    } );
+
                     it( "can create multiple CTEs where the second CTE is not recursive", function() {
                         testCase( function( builder ) {
                             builder
@@ -2109,6 +2126,7 @@ component extends="testbox.system.BaseSpec" {
             if ( isSimpleValue( expected ) ) {
                 expected = { sql: expected, bindings: [] };
             }
+            debug( sql );
             expect( sql ).toBeWithCase( expected.sql );
             expect( getTestBindings( builder ) ).toBe( expected.bindings );
         } catch ( any e ) {

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -546,6 +546,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function commonTableExpressionWithRecursiveWithColumns() {
+        return {
+            sql: "WITH RECURSIVE `UsersCTE` `usersId`,`contactsId` AS (SELECT `users`.`id` AS `usersId`, `contacts`.`id` AS `contactsId` FROM `users` INNER JOIN `contacts` ON `users`.`id` = `contacts`.`id` WHERE `users`.`age` > ?) SELECT * FROM `UsersCTE` WHERE `user`.`id` NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
     function commonTableExpressionWithRecursive() {
         return {
             sql: "WITH RECURSIVE `UsersCTE` AS (SELECT * FROM `users` INNER JOIN `contacts` ON `users`.`id` = `contacts`.`id` WHERE `users`.`age` > ?) SELECT * FROM `UsersCTE` WHERE `user`.`id` NOT IN (?, ?)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -571,6 +571,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function commonTableExpressionWithRecursiveWithColumns() {
+        return {
+            sql: "WITH ""USERSCTE"" ""USERSID"",""CONTACTSID"" AS (SELECT ""USERS"".""ID"" AS ""USERSID"", ""CONTACTS"".""ID"" AS ""CONTACTSID"" FROM ""USERS"" INNER JOIN ""CONTACTS"" ON ""USERS"".""ID"" = ""CONTACTS"".""ID"" WHERE ""USERS"".""AGE"" > ?) SELECT * FROM ""USERSCTE"" WHERE ""USER"".""ID"" NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
     function commonTableExpressionMultipleCTEsWithRecursive() {
         return {
             sql: "WITH ""USERSCTE"" AS (SELECT * FROM ""USERS"" INNER JOIN ""CONTACTS"" ON ""USERS"".""ID"" = ""CONTACTS"".""ID"" WHERE ""USERS"".""AGE"" > ?), ""ORDERCTE"" AS (SELECT * FROM ""ORDERS"" WHERE ""CREATED"" > ?) SELECT * FROM ""USERSCTE"" WHERE ""USER"".""ID"" NOT IN (?, ?)",

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -562,6 +562,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function commonTableExpressionWithRecursiveWithColumns() {
+        return {
+            sql: "WITH RECURSIVE ""UsersCTE"" (""usersId"",""contactsId"") AS (SELECT ""users"".""id"" AS ""usersId"", ""contacts"".""id"" AS ""contactsId"" FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
     function commonTableExpressionMultipleCTEsWithRecursive() {
         return {
             sql: "WITH RECURSIVE ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?), ""OrderCTE"" AS (SELECT * FROM ""orders"" WHERE ""created"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -553,6 +553,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function commonTableExpressionWithRecursiveWithColumns() {
+        return {
+            sql: ";WITH [UsersCTE] ([usersId],[contactsId]) AS (SELECT [users].[id] AS [usersId], [contacts].[id] AS [contactsId] FROM [users] INNER JOIN [contacts] ON [users].[id] = [contacts].[id] WHERE [users].[age] > ?) SELECT * FROM [UsersCTE] WHERE [user].[id] NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
     function commonTableExpressionMultipleCTEsWithRecursive() {
         return {
             sql: ";WITH [UsersCTE] AS (SELECT * FROM [users] INNER JOIN [contacts] ON [users].[id] = [contacts].[id] WHERE [users].[age] > ?), [OrderCTE] AS (SELECT * FROM [orders] WHERE [created] > ?) SELECT * FROM [UsersCTE] WHERE [user].[id] NOT IN (?, ?)",


### PR DESCRIPTION
Both SQL Server and Postgres require CTE columns be wrapped in parentheses.  This hotfix adds a new property called `cteColumnsRequireParentheses` which can be overridden by a grammar implementation.  I also added constructors for Postgres and SQL Server so they can override the default.