### PR TITLE
feat(QueryUtils): Auto derive the correct numeric sql types

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -13,7 +13,10 @@ component {
             "preventDuplicateJoins": false,
             "strictDateDetection": false,
             "numericSQLType": "CF_SQL_NUMERIC",
+            "integerSQLType": "CF_SQL_INTEGER",
+            "decimalSQLType": "CF_SQL_DECIMAL",
             "autoAddScale": true,
+            "autoDeriveNumericType": false,
             "defaultOptions": {}
         };
 
@@ -25,7 +28,11 @@ component {
             .map( alias = "QueryUtils@qb", force = true )
             .to( "qb.models.Query.QueryUtils" )
             .initArg( name = "strictDateDetection", value = settings.strictDateDetection )
-            .initArg( name = "numericSQLType", value = settings.numericSQLType );
+            .initArg( name = "numericSQLType", value = settings.numericSQLType )
+            .initArg( name = "autoAddScale", value = settings.autoAddScale )
+            .initArg( name = "autoDeriveNumericType", value = settings.autoDeriveNumericType )
+            .initArg( name = "integerSQLType", value = settings.integerSQLType )
+            .initArg( name = "decimalSQLType", value = settings.decimalSQLType );
 
         binder
             .map( alias = "QueryBuilder@qb", force = true )

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -270,7 +270,6 @@ component displayname="QueryBuilder" accessors="true" {
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
-        variables.utils.setBuilder( this );
 
         setReturnFormat( arguments.returnFormat );
         setPreventDuplicateJoins( arguments.preventDuplicateJoins );

--- a/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
@@ -15,12 +15,30 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
                 expect( utils.inferSqlType( "a string" ) ).toBe( "CF_SQL_VARCHAR" );
             } );
 
-            it( "numbers", function() {
-                if ( isACF2016() ) {
-                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_VARCHAR" );
-                } else {
-                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
-                }
+            describe( "numbers", function() {
+                it( "integers", function() {
+                    if ( isACF2016() ) {
+                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_VARCHAR" );
+                    } else {
+                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
+                        variables.utils.setAutoDeriveNumericType( true );
+                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_INTEGER" );
+                        variables.utils.setAutoDeriveNumericType( false );
+                    }
+                } );
+
+                it( "decimals", function() {
+                    if ( isACF2016() ) {
+                        variables.utils.setStrictDateDetection( true );
+                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_VARCHAR" );
+                        variables.utils.setStrictDateDetection( false );
+                    } else {
+                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_NUMERIC" );
+                        variables.utils.setAutoDeriveNumericType( true );
+                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_DECIMAL" );
+                        variables.utils.setAutoDeriveNumericType( false );
+                    }
+                } );
             } );
 
             it( "dates", function() {


### PR DESCRIPTION
In previous versions, qb would use `CF_SQL_NUMERIC` for all numeric sql types.  This can cause performance issues as some JDBC drivers interpret `CF_SQL_NUMERIC` as `float` and then the database has to convert it from there.  This change introduces some optional settings for `QueryUtils` to solve this problem: `autoDeriveNumericType`, `integerSqlType`, and `decimalSqlType`.  When `autoDeriveNumericType` is set to true, the numeric value will be checked against a regex and either the `integerSqlType` or the `decimalSqlType` will be used.  This is an opt-in feature that will likely become the default in the next major version of qb.

Thanks to @dswitzer for the issue and help along the way.

Resolves #230 