### PR TITLE
chore(CI): Update GHA to avoid deprecated output syntax

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -50,7 +50,7 @@ jobs:
     name: Format
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,7 +17,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -48,7 +48,7 @@ jobs:
   #     GA_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
   #   steps:
       # - name: Checkout Repository
-      #   uses: actions/checkout@v2
+      #   uses: actions/checkout@v3.2.0
       #   with:
       #     fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -49,7 +49,7 @@ jobs:
       GA_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Get Current Version
         id: current_version
-        run: echo "::set-output name=version::`cat box.json | jq '.version' -r`"
+        run: echo "version=`cat box.json | jq '.version' -r`" >> $GITHUB_OUTPUT
 
       - name: Upload API Docs to S3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Get Current Version
         id: current_version
-        run: echo "::set-output name=version::`cat box.json | jq '.version' -r`"
+        run: echo "version=`cat box.json | jq '.version' -r`" >> $GITHUB_OUTPUT
 
       - name: Upload API Docs to S3
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
Lots of third-party actions needed updating to avoid deprecated GHA syntax.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/