### PR TITLE
feat(SQLCommenter): Add SQLCommenter support for ColdBox

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -17,7 +17,15 @@ component {
             "decimalSQLType": "CF_SQL_DECIMAL",
             "autoAddScale": true,
             "autoDeriveNumericType": false,
-            "defaultOptions": {}
+            "defaultOptions": {},
+            "sqlCommenter": {
+                "enabled": false,
+                "commenters": [
+                    { "class": "FrameworkCommenter@qb", "properties": {} },
+                    { "class": "RouteInfoCommenter@qb", "properties": {} },
+                    { "class": "DBInfoCommenter@qb", "properties": {} }
+                ]
+            }
         };
 
         interceptorSettings = { "customInterceptionPoints": "preQBExecute,postQBExecute" };
@@ -42,6 +50,7 @@ component {
             .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
             .initArg( name = "returnFormat", value = settings.defaultReturnFormat )
             .initArg( name = "defaultOptions", value = settings.defaultOptions );
+            .initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" );
 
         binder
             .map( alias = "SchemaBuilder@qb", force = true )

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -69,6 +69,12 @@ component displayname="QueryBuilder" accessors="true" {
      */
     property name="defaultOptions";
 
+    /**
+     * The defined SQLCommenter for this builder.
+     * Defaults to a NullSQLCommenter that does nothing.
+     */
+    property name="sqlCommenter";
+
     /******************** Query Properties ********************/
 
     /**
@@ -266,7 +272,8 @@ component displayname="QueryBuilder" accessors="true" {
         paginationCollector = new cbpaginator.models.Pagination(),
         columnFormatter,
         parentQuery,
-        defaultOptions = {}
+        defaultOptions = {},
+        sqlCommenter = new qb.models.SQLCommenter.NullSQLCommenter()
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
@@ -284,6 +291,7 @@ component displayname="QueryBuilder" accessors="true" {
         }
         setDefaultOptions( arguments.defaultOptions );
         setReturnFormat( arguments.returnFormat );
+        setSqlCommenter( arguments.sqlCommenter );
 
         setDefaultValues();
 
@@ -3434,7 +3442,13 @@ component displayname="QueryBuilder" accessors="true" {
     private any function runQuery( required string sql, struct options = {}, string returnObject = "query" ) {
         structAppend( arguments.options, getDefaultOptions(), false );
         var result = grammar.runQuery(
-            sql,
+            variables.sqlCommenter.appendSqlComments(
+                sql,
+                arguments.options.keyExists( "datasource" ) && !isNull( arguments.options.datasource ) ? arguments.options.datasource : javacast(
+                    "null",
+                    ""
+                )
+            ),
             getBindings( except = getAggregate().isEmpty() ? [] : [ "select" ] ),
             arguments.options,
             returnObject

--- a/models/SQLCommenter/ColdBoxSQLCommenter.cfc
+++ b/models/SQLCommenter/ColdBoxSQLCommenter.cfc
@@ -1,0 +1,54 @@
+component extends="SQLCommenter" singleton {
+
+    /**
+     * All the qb module settings so we can inspect the sqlCommenter settings.
+     */
+    property name="settings" inject="coldbox:moduleSettings:qb";
+
+    /**
+     * WireBox Injector
+     */
+    property name="wirebox" inject="wirebox";
+
+    /**
+     * An array of configured Commenter components.
+     * These are used to fetch the comments for each SQL query.
+     */
+    property name="commenters" type="array";
+
+    /**
+     * Set up the commenters array with configured Commenter components.
+     */
+    function onDIComplete() {
+        variables.commenters = variables.settings.sqlCommenter.commenters.map( ( commenterInfo ) => {
+            param commenterInfo.properties = {};
+            if ( !commenterInfo.keyExists( "class" ) ) {
+                throw( "A commenter must have a class pointing to a WireBox mapping" );
+            }
+
+            return variables.wirebox.getInstance( commenterInfo.class ).setProperties( commenterInfo.properties );
+        } );
+    }
+
+    /**
+     * Gathers comments from the configured commenters and appends it to the SQL query.
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        if ( !settings.sqlCommenter.enabled ) {
+            return arguments.sql;
+        }
+
+        var comments = variables.commenters.reduce( ( acc, commenter ) => {
+            acc.append( commenter.getComments( sql, isNull( datasource ) ? javacast( "null", "" ) : datasource ), true );
+        }, {} );
+
+        return appendCommentsToSQL( arguments.sql, comments );
+    }
+
+}

--- a/models/SQLCommenter/Commenters/DBInfoCommenter.cfc
+++ b/models/SQLCommenter/Commenters/DBInfoCommenter.cfc
@@ -1,0 +1,23 @@
+component singleton accessors="true" {
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        if ( isNull( arguments.datasource ) ) {
+            cfdbinfo( type = "version", name = "local.dbInfo" );
+        } else {
+            cfdbinfo( type = "version", name = "local.dbInfo", datasource = arguments.datasource );
+        }
+
+        return { "dbDriver": dbInfo.DRIVER_VERSION };
+    }
+
+}

--- a/models/SQLCommenter/Commenters/FrameworkCommenter.cfc
+++ b/models/SQLCommenter/Commenters/FrameworkCommenter.cfc
@@ -1,0 +1,19 @@
+component singleton accessors="true" {
+
+    property name="coldboxVersion" inject="coldbox:coldboxSetting:version";
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        return { "version": "coldbox-#variables.coldboxVersion#" };
+    }
+
+}

--- a/models/SQLCommenter/Commenters/ICommenter.cfc
+++ b/models/SQLCommenter/Commenters/ICommenter.cfc
@@ -1,0 +1,17 @@
+interface displayName="ICommenter" {
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource );
+
+    // You can use `accessors="true"` with a `property name="properties";` to implement these methods.
+    public ICommenter function setProperties( required struct properties );
+    public struct function getProperties();
+
+}

--- a/models/SQLCommenter/Commenters/RouteInfoCommenter.cfc.cfc
+++ b/models/SQLCommenter/Commenters/RouteInfoCommenter.cfc.cfc
@@ -1,0 +1,25 @@
+component singleton accessors="true" {
+
+    property name="wirebox" inject="wirebox";
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        var event = wirebox.getInstance( "coldbox:requestContext" );
+        return {
+            "event": event.getCurrentEvent(),
+            "handler": event.getCurrentHandler(),
+            "action": event.getCurrentAction(),
+            "route": event.getCurrentRoutedURL()
+        };
+    }
+
+}

--- a/models/SQLCommenter/NullSQLCommenter.cfc
+++ b/models/SQLCommenter/NullSQLCommenter.cfc
@@ -1,0 +1,16 @@
+component extends="SQLCommenter" singleton {
+
+    /**
+     * Returns the SQL unchanged for the NullSQLCommenter.
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        return arguments.sql;
+    }
+
+}

--- a/models/SQLCommenter/SQLCommenter.cfc
+++ b/models/SQLCommenter/SQLCommenter.cfc
@@ -1,0 +1,180 @@
+/**
+ * @doc_abstract true
+ */
+component singleton {
+
+    /**
+     * Gathers comments from the configured commenters and appends it to the SQL query.
+     * @doc_abstract true
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        throw( "appendSqlComments is an abstract method and must be implemented in a subclass." );
+    }
+
+    /**
+     * Serializes and appends a struct of key/value comment pairs to the provided SQL string.
+     *
+     * @sql       The SQL string to add the serialized comments to.
+     * @comments  The key/value pairs to serialize and append.
+     *
+     * @return    Commented SQL string
+     */
+    public string function appendCommentsToSQL( required string sql, required struct comments ) {
+        // DO NOT mutate a statement with an already present comment
+        if ( containsSQLComment( arguments.sql ) ) {
+            return arguments.sql;
+        }
+
+        var serializedComments = [];
+        for ( var key in arguments.comments ) {
+            serializedComments.append( serializeComment( key, arguments.comments[ key ] ) );
+        }
+
+        arraySort( serializedComments, "textnocase" )
+
+        return arguments.sql & " /*#arrayToList( serializedComments )#*/";
+    }
+
+    /**
+     * Parses a commented SQL string into the SQL and a struct of the key/value pair comments.
+     *
+     * @sql     The commented SQL string to parse.
+     *
+     * @return  { "sql": string, "comments": struct }
+     */
+    public struct function parseCommentedSQL( required string sql ) {
+        var commentStartPosition = find( "/*", arguments.sql ) - 1;
+        return {
+            "sql": left( arguments.sql, commentStartPosition - 1 ),
+            "comments": parseCommentString(
+                mid( arguments.sql, commentStartPosition + 1, len( arguments.sql ) - commentStartPosition + 1 )
+            )
+        };
+    }
+
+    /**
+     * Parses a comment string into a struct.
+     *
+     * @commentString  The comment string to parse into a struct
+     *
+     * @return         A struct of key/value pairs from the comment.
+     */
+    private struct function parseCommentString( required string commentString ) {
+        arguments.commentString = trim( arguments.commentString );
+        arguments.commentString = replace( arguments.commentString, "/*", "" );
+        arguments.commentString = replace( arguments.commentString, "*/", "" );
+        return listToArray( arguments.commentString ).reduce( ( acc, serializedKeyValuePair ) => {
+            var key = decodeFromURL( unescapeMetaCharacters( listFirst( serializedKeyValuePair, "=" ) ) );
+            var value = decodeFromURL(
+                unescapeMetaCharacters( unescapeSQL( listLast( serializedKeyValuePair, "=" ) ) )
+            );
+            acc[ key ] = value;
+            return acc;
+        }, {} );
+    }
+
+    /**
+     * Returns true if the SQL already contains a comment.
+     *
+     * @sql     The SQL to check for a comment.
+     *
+     * @return  True if the SQL already contains a comment.
+     */
+    private boolean function containsSQLComment( required string sql ) {
+        return find( "--", arguments.sql ) > 0 || find( "/*", arguments.sql ) > 0;
+    }
+
+    /**
+     * Serializes a key/value pair for use in a comment string.
+     *
+     * @key     The key to serialize.
+     * @value   The value to serialize.
+     *
+     * @return  A serialized string for the key/value pair.
+     */
+    private string function serializeComment( required string key, required string value ) {
+        return serializeKey( arguments.key ) & "=" & serializeValue( arguments.value );
+    }
+
+    /**
+     * Serializes a key for use in a comment string.
+     *
+     * @key     The key to serialize.
+     *
+     * @return  The serialized key.
+     */
+    private string function serializeKey( required string key ) {
+        return escapeMetaCharacters( encodeForURL( arguments.key ) );
+    }
+
+    /**
+     * Serializes a value for use in a comment string.
+     *
+     * @value   The value to serialize.
+     *
+     * @return  The serialized value.
+     */
+    private string function serializeValue( required string value ) {
+        return escapeSQL(
+            escapeMetaCharacters(
+                replace(
+                    encodeForURL( arguments.value ),
+                    "+",
+                    "%20",
+                    "all"
+                )
+            )
+        );
+    }
+
+    /**
+     * Escapes meta characters such as single quotes in the passed in string.
+     *
+     * @str     The string to escape meta characters.
+     *
+     * @return  The string with meta characters escaped.
+     */
+    private string function escapeMetaCharacters( required string str ) {
+        return replace( arguments.str, "'", "\'", "all" );
+    }
+
+    /**
+     * Unescapes meta characters such as single quotes in the passed in string.
+     *
+     * @str     The string to unescape meta characters.
+     *
+     * @return  The string without meta characters escaped.
+     */
+    private string function unescapeMetaCharacters( required string str ) {
+        return replace( arguments.str, "\'", "'", "all" );
+    }
+
+    /**
+     * Escapes a string for SQL by surrounding it in single quotes.
+     *
+     * @str      The string to escape for SQL.
+     *
+     * @returns  The string escaped for SQL.
+     */
+    private string function escapeSQL( required string str ) {
+        return "'" & arguments.str & "'";
+    }
+
+    /**
+     * Unescapes a string for SQL by removing the surrounding single quotes.
+     *
+     * @str      The string to unescape for SQL.
+     *
+     * @returns  The string unescaped for SQL.
+     */
+    private string function unescapeSQL( required string str ) {
+        return mid( arguments.str, 2, len( arguments.str ) - 2 );
+    }
+
+}

--- a/tests/specs/SQLCommenterSpec.cfc
+++ b/tests/specs/SQLCommenterSpec.cfc
@@ -1,0 +1,74 @@
+component extends="testbox.system.BaseSpec" {
+
+    function beforeAll() {
+        variables.sqlCommenter = new qb.models.SQLCommenter.SQLCommenter();
+    }
+
+    function run() {
+        describe( "SQLCommenter", () => {
+            describe( "containsSQLComment", () => {
+                it( "can detect if a SQL statement has a comment in it", function() {
+                    makePublic( variables.sqlCommenter, "containsSQLComment", "containsSQLCommentPublic" );
+                    expect(
+                        variables.sqlCommenter.containsSQLCommentPublic( "SELECT * /* should not use star */ FROM users" )
+                    ).toBeTrue();
+                    expect( variables.sqlCommenter.containsSQLCommentPublic( "SELECT * FROM users" ) ).toBeFalse();
+                } );
+            } );
+
+            describe( "serializeValue", () => {
+                it( "can serialize values in a key value pair", function() {
+                    makePublic( variables.sqlCommenter, "serializeValue", "serializeValuePublic" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "DROP TABLE FOO" ) ).toBe( "'DROP%20TABLE%20FOO'" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "/param first" ) ).toBe( "'%2Fparam%20first'" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "1234" ) ).toBe( "'1234'" );
+                } );
+            } );
+
+            describe( "serializeComment", () => {
+                it( "can serialize key value pair comments", function() {
+                    makePublic( variables.sqlCommenter, "serializeComment", "serializeCommentPublic" );
+                    expect( variables.sqlCommenter.serializeCommentPublic( "route", "/polls 1000" ) ).toBe( "route='%2Fpolls%201000'" );
+                    expect( variables.sqlCommenter.serializeCommentPublic( "name''", """DROP TABLE USERS'""" ) ).toBe( "name%27%27='%22DROP%20TABLE%20USERS%27%22'" );
+                } );
+            } );
+
+            describe( "appendCommentsToSQL", () => {
+                it( "serializes comments on the end of a sql query", function() {
+                    var commentedSQL = variables.sqlCommenter.appendCommentsToSQL(
+                        sql = "SELECT * FROM foo",
+                        comments = {
+                            "event": "Main.index",
+                            "framework": "coldbox-6.0.0",
+                            "handler": "Main",
+                            "action": "index",
+                            "route": "/",
+                            "dbDriver": "mysql-connector-java-8.0.25 (Revision: 08be9e9b4cba6aa115f9b27b215887af40b159e0)"
+                        }
+                    );
+
+                    expect( commentedSQL ).toBeWithCase(
+                        "SELECT * FROM foo /*action='index',dbDriver='mysql-connector-java-8.0.25%20%28Revision%3A%2008be9e9b4cba6aa115f9b27b215887af40b159e0%29',event='Main.index',framework='coldbox-6.0.0',handler='Main',route='%2F'*/"
+                    );
+                } );
+            } );
+
+            describe( "parseCommentedSQL", () => {
+                it( "can parse a commented SQL string into the sql and the comments", function() {
+                    var commentedSQL = "SELECT * FROM foo /*action='index',dbDriver='mysql-connector-java-8.0.25%20%28Revision%3A%2008be9e9b4cba6aa115f9b27b215887af40b159e0%29',event='Main.index',framework='coldbox-6.0.0',handler='Main',route='%2F'*/";
+                    var sqlAndComments = variables.sqlCommenter.parseCommentedSQL( commentedSQL );
+                    expect( sqlAndComments.sql ).toBeWithCase( "SELECT * FROM foo" );
+                    expect( sqlAndComments.comments ).toBe( {
+                        "event": "Main.index",
+                        "framework": "coldbox-6.0.0",
+                        "handler": "Main",
+                        "action": "index",
+                        "route": "/",
+                        "dbDriver": "mysql-connector-java-8.0.25 (Revision: 08be9e9b4cba6aa115f9b27b215887af40b159e0)"
+                    } );
+                } );
+            } );
+        } );
+    }
+
+}


### PR DESCRIPTION
[SQLCommenter]((https://google.github.io/sqlcommenter/)) is a standard developed by Google to add context as a trailing comment to SQL statements.  In a non-ColdBox context, this will do nothing.  In a ColdBox context, this can be configured to add any additional information desired.