### PR TITLE
v9.0.0

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "lucee@be", "adobe@2018", "adobe@2021", "adobe@be"]
         javaVersion: ["openjdk8", "openjdk11"]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,17 +19,18 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} javaVersion=${{ matrix.javaVersion }} --noSaveSettings
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        cfengine: ["lucee@5", "lucee@be", "adobe@2016", "adobe@2018", "adobe@be"]
+        cfengine: ["lucee@5", "lucee@be", "adobe@2018", "adobe@2021", "adobe@be"]
         javaVersion: ["openjdk8", "openjdk11"]
         fullNull: ["true", "false"]
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,17 +26,18 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -53,16 +54,17 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install CFFormat
         run: box install commandbox-cfformat
-      
+
       - name: Run CFFormat
         run: box run-script format
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
+        cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -50,7 +50,7 @@ jobs:
     name: Format
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,17 +20,18 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -53,19 +54,20 @@ jobs:
       #     fetch-depth: 0
 
   #     - name: Setup Java JDK
-  #       uses: actions/setup-java@v1.4.3
+  #       uses: actions/setup-java@v3.9.0
   #       with:
-  #         java-version: 11 
+  #         distribution: 'zulu'
+  #         java-version: 11
 
   #     - name: Set Up CommandBox
   #       uses: elpete/setup-commandbox@v1.0.0
-      
+
   #     - name: Install and Configure Semantic Release
   #       run: |
   #         box install commandbox-semantic-release
   #         box config set endpoints.forgebox.APIToken=${{ secrets.FORGEBOX_TOKEN }}
   #         box config set modules.commandbox-semantic-release.plugins='{ "VerifyConditions": "GitHubActionsConditionsVerifier@commandbox-semantic-release", "FetchLastRelease": "ForgeBoxReleaseFetcher@commandbox-semantic-release", "RetrieveCommits": "JGitCommitsRetriever@commandbox-semantic-release", "ParseCommit": "ConventionalChangelogParser@commandbox-semantic-release", "FilterCommits": "DefaultCommitFilterer@commandbox-semantic-release", "AnalyzeCommits": "DefaultCommitAnalyzer@commandbox-semantic-release", "VerifyRelease": "NullReleaseVerifier@commandbox-semantic-release", "GenerateNotes": "GitHubMarkdownNotesGenerator@commandbox-semantic-release", "UpdateChangelog": "FileAppendChangelogUpdater@commandbox-semantic-release", "CommitArtifacts": "NullArtifactsCommitter@commandbox-semantic-release", "PublishRelease": "ForgeBoxReleasePublisher@commandbox-semantic-release", "PublicizeRelease": "GitHubReleasePublicizer@commandbox-semantic-release" }'
-      
+
       # - name: Run Semantic Release
       #   env:
       #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
+        cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,7 +17,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -48,7 +48,7 @@ jobs:
   #     GA_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
   #   steps:
       # - name: Checkout Repository
-      #   uses: actions/checkout@v2
+      #   uses: actions/checkout@v3.2.0
       #   with:
       #     fetch-depth: 0
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '__SEMANTIC RELEASE VERSION UPDATE__')"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
+        cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         fullNull: ["true", "false"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -49,7 +49,7 @@ jobs:
       GA_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Get Current Version
         id: current_version
-        run: echo "::set-output name=version::`cat box.json | jq '.version' -r`"
+        run: echo "version=`cat box.json | jq '.version' -r`" >> $GITHUB_OUTPUT
 
       - name: Upload API Docs to S3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,18 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -54,20 +55,21 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.9.0
         with:
-          java-version: 11 
+          distribution: 'zulu'
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install and Configure Semantic Release
         run: |
           box install commandbox-semantic-release
           box config set endpoints.forgebox.APIToken=${{ secrets.FORGEBOX_TOKEN }}
           box config set modules.commandbox-semantic-release.targetBranch=main
           box config set modules.commandbox-semantic-release.plugins='{ "VerifyConditions": "GitHubActionsConditionsVerifier@commandbox-semantic-release", "FetchLastRelease": "ForgeBoxReleaseFetcher@commandbox-semantic-release", "RetrieveCommits": "JGitCommitsRetriever@commandbox-semantic-release", "ParseCommit": "ConventionalChangelogParser@commandbox-semantic-release", "FilterCommits": "DefaultCommitFilterer@commandbox-semantic-release", "AnalyzeCommits": "DefaultCommitAnalyzer@commandbox-semantic-release", "VerifyRelease": "NullReleaseVerifier@commandbox-semantic-release", "GenerateNotes": "GitHubMarkdownNotesGenerator@commandbox-semantic-release", "UpdateChangelog": "FileAppendChangelogUpdater@commandbox-semantic-release", "CommitArtifacts": "GitHubArtifactsCommitter@commandbox-semantic-release", "PublishRelease": "ForgeBoxReleasePublisher@commandbox-semantic-release", "PublicizeRelease": "GitHubReleasePublicizer@commandbox-semantic-release" }'
-      
+
       - name: Run Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '__SEMANTIC RELEASE VERSION UPDATE__')"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2018", "adobe@2021"]
         fullNull: ["true", "false"]

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -35,6 +35,16 @@ component {
     }
 
     function onLoad() {
+        // Fill out the sqlCommenter commenters array in case users
+        // forget to define it when overriding in their `config/ColdBox.cfc`
+        if ( !settings.sqlCommenter.keyExists( "commenters" ) ) {
+            param settings.sqlCommenter.commenters = [
+                { "class": "FrameworkCommenter@qb", "properties": {} },
+                { "class": "RouteInfoCommenter@qb", "properties": {} },
+                { "class": "DBInfoCommenter@qb", "properties": {} }
+            ];
+        }
+
         binder
             .map( alias = "QueryUtils@qb", force = true )
             .to( "qb.models.Query.QueryUtils" )

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -16,7 +16,7 @@ component {
             "integerSQLType": "CF_SQL_INTEGER",
             "decimalSQLType": "CF_SQL_DECIMAL",
             "autoAddScale": true,
-            "autoDeriveNumericType": false,
+            "autoDeriveNumericType": true,
             "defaultOptions": {},
             "sqlCommenter": {
                 "enabled": false,

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -62,8 +62,8 @@ component {
             .initArg( name = "utils", ref = "QueryUtils@qb" )
             .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
             .initArg( name = "returnFormat", value = settings.defaultReturnFormat )
-            .initArg( name = "defaultOptions", value = settings.defaultOptions );
-            .initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" );
+            .initArg( name = "defaultOptions", value = settings.defaultOptions )
+            .initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" )
             .initArg( name = "shouldMaxRowsOverrideToAll", value = settings.shouldMaxRowsOverrideToAll );
 
         binder

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -11,7 +11,7 @@ component {
             "defaultGrammar": "AutoDiscover@qb",
             "defaultReturnFormat": "array",
             "preventDuplicateJoins": false,
-            "strictDateDetection": false,
+            "strictDateDetection": true,
             "numericSQLType": "CF_SQL_NUMERIC",
             "integerSQLType": "CF_SQL_INTEGER",
             "decimalSQLType": "CF_SQL_DECIMAL",

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -17,7 +17,15 @@ component {
             "decimalSQLType": "CF_SQL_DECIMAL",
             "autoAddScale": true,
             "autoDeriveNumericType": false,
-            "defaultOptions": {}
+            "defaultOptions": {},
+            "sqlCommenter": {
+                "enabled": false,
+                "commenters": [
+                    { "class": "FrameworkCommenter@qb", "properties": {} },
+                    { "class": "RouteInfoCommenter@qb", "properties": {} },
+                    { "class": "DBInfoCommenter@qb", "properties": {} }
+                ]
+            }
         };
 
         interceptorSettings = { "customInterceptionPoints": "preQBExecute,postQBExecute" };
@@ -42,6 +50,7 @@ component {
             .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
             .initArg( name = "returnFormat", value = settings.defaultReturnFormat )
             .initArg( name = "defaultOptions", value = settings.defaultOptions );
+            .initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" );
 
         binder
             .map( alias = "SchemaBuilder@qb", force = true )

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -25,6 +25,9 @@ component {
                     { "class": "RouteInfoCommenter@qb", "properties": {} },
                     { "class": "DBInfoCommenter@qb", "properties": {} }
                 ]
+            },
+            "shouldMaxRowsOverrideToAll": function( maxRows ) {
+                return maxRows <= 0;
             }
         };
 
@@ -51,6 +54,7 @@ component {
             .initArg( name = "returnFormat", value = settings.defaultReturnFormat )
             .initArg( name = "defaultOptions", value = settings.defaultOptions );
             .initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" );
+            .initArg( name = "shouldMaxRowsOverrideToAll", value = settings.shouldMaxRowsOverrideToAll );
 
         binder
             .map( alias = "SchemaBuilder@qb", force = true )

--- a/README.md
+++ b/README.md
@@ -74,6 +74,48 @@ qb enables you to explore new ways of organizing your code by letting you pass a
 Here's a gist with an example of the powerful models you can create with this!
 https://gist.github.com/elpete/80d641b98025f16059f6476561d88202
 
+## SQLite Datasource Setup
+
+To use the SQLite grammar for qb you will need to setup a datasource that connects to a SQLite database.
+
+### Install the SQLite JDBC driver
+
+1. Download the [latest release](https://github.com/xerial/sqlite-jdbc/releases) of the SQLite JDBC Driver i.e. https://github.com/xerial/sqlite-jdbc/releases/download/3.40.0.0/sqlite-jdbc-3.40.0.0.jar
+2. Drop it in the `/lib` directory
+3. Configure the application to load the library by adding this line in your `Application.cfc` file.
+
+    ```
+    this.javaSettings = { loadPaths : [ ".\lib" ] };
+    ```
+4. Restart the server
+
+### Configure the Datasource
+
+You can configure your datasource for Lucee or Adobe Coldfusion using the steps below. You can also use [cfconfig](https://cfconfig.ortusbooks.com/using-the-cli/installation) with CommandBox to do it automatically for you. 
+
+For both Lucee and ACF you need to set the JDBC Driver class to `org.sqlite.JDBC`. Then you need to specify the JDBC connection string as `jdbc:sqlite:<your database path>`. i.e. `jdbc:sqlite:C:/data/my_database.db`
+
+**Lucee**
+1. Navigate to Datasources in the Lucee administrator
+2. Enter datasource name
+3. Select Type: Other - JDBC Driver 
+4. Click Create
+5. Enter `org.sqlite.JDBC` for Class
+6. Enter the Connection String: `jdbc:sqlite:<db path>`
+7. Click Create
+
+**ACF**
+1. Navigate to Datasources in the ACF administrator
+2. Enter the datasource name under Add New Data Source
+3. Select `other` for the datasource driver
+4. Click Add
+5. Enter `org.sqlite.JDBC` for the Driver Class
+6. Use `org.sqlite.JDBC` for the Driver Name
+7. Etner the JDBC URL: `jdbc:sqlite:<db path>`
+8. Click Submit
+
+
 ## Full Docs
 
 You can browse the full documentation at https://qb.ortusbooks.com
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Using qb, you can:
 
 ## Requirements
 
-+ Adobe ColdFusion 2016+
++ Adobe ColdFusion 2018+
 + Lucee 5+
 
 ## Installation
@@ -91,14 +91,14 @@ To use the SQLite grammar for qb you will need to setup a datasource that connec
 
 ### Configure the Datasource
 
-You can configure your datasource for Lucee or Adobe Coldfusion using the steps below. You can also use [cfconfig](https://cfconfig.ortusbooks.com/using-the-cli/installation) with CommandBox to do it automatically for you. 
+You can configure your datasource for Lucee or Adobe Coldfusion using the steps below. You can also use [cfconfig](https://cfconfig.ortusbooks.com/using-the-cli/installation) with CommandBox to do it automatically for you.
 
 For both Lucee and ACF you need to set the JDBC Driver class to `org.sqlite.JDBC`. Then you need to specify the JDBC connection string as `jdbc:sqlite:<your database path>`. i.e. `jdbc:sqlite:C:/data/my_database.db`
 
 **Lucee**
 1. Navigate to Datasources in the Lucee administrator
 2. Enter datasource name
-3. Select Type: Other - JDBC Driver 
+3. Select Type: Other - JDBC Driver
 4. Click Create
 5. Enter `org.sqlite.JDBC` for Class
 6. Enter the Connection String: `jdbc:sqlite:<db path>`

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"qb",
-    "version":"8.9.1",
+    "version":"9.0.0-beta.1",
     "author":"Eric Peterson",
     "homepage":"https://github.com/coldbox-modules/qb",
     "documentation":"https://github.com/coldbox-modules/qb",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"qb",
-    "version":"9.0.0-beta.2",
+    "version":"9.0.0-beta.3",
     "author":"Eric Peterson",
     "homepage":"https://github.com/coldbox-modules/qb",
     "documentation":"https://github.com/coldbox-modules/qb",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"qb",
-    "version":"9.0.0-beta.1",
+    "version":"9.0.0-beta.2",
     "author":"Eric Peterson",
     "homepage":"https://github.com/coldbox-modules/qb",
     "documentation":"https://github.com/coldbox-modules/qb",

--- a/models/Grammars/AutoDiscover.cfc
+++ b/models/Grammars/AutoDiscover.cfc
@@ -15,6 +15,8 @@ component singleton {
                 return wirebox.getInstance( "SQLServerGrammar@qb" );
             case "Oracle":
                 return wirebox.getInstance( "OracleGrammar@qb" );
+            case "SQLite":
+                return wirebox.getInstance( "SQLiteGrammar@qb" );
             default:
                 return wirebox.getInstance( "BaseGrammar@qb" );
         }

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1367,6 +1367,10 @@ component displayname="Grammar" accessors="true" singleton {
         return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP INDEX #wrapValue( commandParameters.name )#";
     }
 
+    function compileDropIndex( blueprint, commandParameters ) {
+        return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP INDEX #wrapValue( commandParameters.name )#";
+    }
+
     function compileDropForeignKey( blueprint, commandParameters ) {
         return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP CONSTRAINT #wrapValue( commandParameters.name )#";
     }

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -837,6 +837,14 @@ component displayname="Grammar" accessors="true" singleton {
         if ( aggregate.keyExists( "defaultValue" ) && !isNull( aggregate.defaultValue ) ) {
             aggString = "COALESCE(#aggString#, #aggregate.defaultValue#)";
         }
+
+        if ( !query.getUnions().isEmpty() ) {
+            var clonedQuery = query.clone().setAggregate( {} );
+            query.reset();
+            query.setAggregate( arguments.aggregate );
+            query.fromSub( "qb_aggregate_source", clonedQuery );
+        }
+
         return "SELECT #aggString# AS ""aggregate""";
     }
 

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -774,7 +774,9 @@ component displayname="Grammar" accessors="true" singleton {
             } )
             .toList( ", " );
 
-        return "INSERT INTO #wrapTable( arguments.query.getFrom() )# (#columnsString#) #compileSelect( arguments.source )#";
+        return trim(
+            compileCommonTables( query, query.getCommonTables() ) & " INSERT INTO #wrapTable( arguments.query.getFrom() )# (#columnsString#) #compileSelect( arguments.source )#"
+        );
     }
 
     /**

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -233,6 +233,10 @@ component displayname="Grammar" accessors="true" singleton {
         return select & columns.map( wrapColumn ).toList( ", " );
     }
 
+    public string function compileConcat( required string alias, required array items ) {
+        return "CONCAT(#arrayToList( items )#) AS #wrapAlias( alias )#";
+    }
+
     /**
      * Compiles the table portion of a sql statement.
      *

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -837,7 +837,8 @@ component displayname="Grammar" accessors="true" singleton {
         if ( aggregate.isEmpty() ) {
             return "";
         }
-        var aggString = "#uCase( aggregate.type )#(#query.getDistinct() ? "DISTINCT " : ""##wrapColumn( aggregate.column )#)";
+        var shouldIncludeDistinct = query.getDistinct() && aggregate.column != "*";
+        var aggString = "#uCase( aggregate.type )#(#shouldIncludeDistinct ? "DISTINCT " : ""##wrapColumn( aggregate.column )#)";
         if ( aggregate.keyExists( "defaultValue" ) && !isNull( aggregate.defaultValue ) ) {
             aggString = "COALESCE(#aggString#, #aggregate.defaultValue#)";
         }

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1432,6 +1432,10 @@ component displayname="Grammar" accessors="true" singleton {
         return "FLOAT(#column.getLength()#,#column.getPrecision()#)";
     }
 
+    function typeGUID( column ) {
+        return typeChar( column, 36 );
+    }
+
     function typeInteger( column ) {
         return arrayToList(
             arrayFilter( [ "INTEGER", isNull( column.getPrecision() ) ? "" : "(#column.getPrecision()#)" ], function( item ) {
@@ -1462,7 +1466,7 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     function typeUUID( column ) {
-        return typeChar( column, 36 );
+        return typeChar( column, 35 );
     }
 
     function typeLineString( column ) {

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -127,7 +127,7 @@ component displayname="Grammar" accessors="true" singleton {
      */
     private function tryPostInterceptor( data ) {
         if ( structKeyExists( application, "applicationName" ) && application.applicationName == "CommandBox CLI" ) {
-            variables.interceptorService.announceInterception( "postQBExecute", data );
+            variables.interceptorService.announce( "postQBExecute", data );
             return;
         }
 

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -127,6 +127,31 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         );
     }
 
+    /**
+     * Compile a Builder's query into an insert using string.
+     *
+     * @query The Builder instance.
+     * @columns The array of columns into which to insert.
+     * @source The source builder object to insert from.
+     *
+     * @return string
+     */
+    public string function compileInsertUsing(
+        required any query,
+        required array columns,
+        required QueryBuilder source
+    ) {
+        var columnsString = arguments.columns
+            .map( function( column ) {
+                return wrapColumn( column.formatted );
+            } )
+            .toList( ", " );
+
+        var cteClause = query.getCommonTables().isEmpty() ? "" : " #compileCommonTables( query, query.getCommonTables() )#";
+
+        return "INSERT INTO #wrapTable( arguments.query.getFrom() )# (#columnsString#)#cteClause# #compileSelect( arguments.source )#";
+    }
+
     public string function compileUpsert(
         required QueryBuilder qb,
         required array insertColumns,

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -438,6 +438,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP CONSTRAINT #wrapValue( commandParameters.name )#";
     }
 
+    function compileDropIndex( blueprint, commandParameters ) {
+        return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP CONSTRAINT #wrapValue( commandParameters.name )#";
+    }
+
     function generateIfExists( blueprint ) {
         return "";
     }

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -180,7 +180,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
             .toList( ", " );
         var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
 
-        return insertString & " ON CONFLICT (#constraintString#) DO UPDATE #updateString##returningClause#";
+        return insertString & " ON CONFLICT (#constraintString#) DO UPDATE SET #updateString##returningClause#";
     }
 
     /*===================================

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -352,6 +352,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP CONSTRAINT #wrapValue( commandParameters.name )#";
     }
 
+    function compileDropIndex( blueprint, commandParameters ) {
+        return "DROP INDEX #wrapValue( commandParameters.name )#";
+    }
+
     function compileDropAllObjects( options, schema = "" ) {
         var tables = getAllTableNames( options, schema );
         var tableList = arrayToList(

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -19,171 +19,174 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =           Query Builder           =
     ===================================*/
 
-        /**
-         * Compiles the lock portion of a sql statement.
-         *
-         * @query The Builder instance.
-         * @lockType The lock type to compile.
-         *
-         * @return string
-         */
-        private string function compileLockType( required query, required string lockType ) {
+    /**
+     * Compiles the lock portion of a sql statement.
+     *
+     * @query The Builder instance.
+     * @lockType The lock type to compile.
+     *
+     * @return string
+     */
+    private string function compileLockType( required query, required string lockType ) {
+        return "";
+    }
+
+    /**
+     * Compiles the offset portion of a sql statement.
+     *
+     * @query The Builder instance.
+     * @offsetValue The offset value.
+     *
+     * @return string
+     */
+    private string function compileOffsetValue( required QueryBuilder query, offsetValue ) {
+        if ( isNull( arguments.offsetValue ) ) {
             return "";
         }
 
-        /**
-         * Compiles the offset portion of a sql statement.
-         *
-         * @query The Builder instance.
-         * @offsetValue The offset value.
-         *
-         * @return string
-         */
-        private string function compileOffsetValue( required QueryBuilder query, offsetValue ) {
-            if ( isNull( arguments.offsetValue ) ) {
-                return "";
-            }
-
-            //SQLite requires LIMIT when using OFFSET. A negative integer means no limit
-            if ( isNull( query.getLimitValue() ) ) {
-                return "LIMIT -1 OFFSET #offsetValue#";
-            }
-
-            return "OFFSET #offsetValue#";
+        // SQLite requires LIMIT when using OFFSET. A negative integer means no limit
+        if ( isNull( query.getLimitValue() ) ) {
+            return "LIMIT -1 OFFSET #offsetValue#";
         }
 
-            /**
-             * Compile a Builder's query into an insert string.
-             *
-             * @query The Builder instance.
-             * @columns The array of columns into which to insert.
-             * @values The array of values to insert.
-             *
-             * @return string
-             */
-            public string function compileInsert( required QueryBuilder query, required array columns, required array values ) {
-                var returningColumns = query
-                    .getReturning()
-                    .map( wrapColumn )
-                    .toList( ", " );
-                var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
-                return super.compileInsert( argumentCollection = arguments ) & returningClause;
-            }
+        return "OFFSET #offsetValue#";
+    }
 
-            /**
-             * Compile a Builder's query into an insert string ignoring duplicate key values.
-             *
-             * @qb The Builder instance.
-             * @columns The array of columns into which to insert.
-             * @target The array of key columns to match.
-             * @values The array of values to insert.
-             *
-             * @return string
-             */
-            public string function compileInsertIgnore(
-                required QueryBuilder qb,
-                required array columns,
-                required array target,
-                required array values
-            ) {
-                return replace(
-                    compileInsert( arguments.qb, arguments.columns, arguments.values ),
-                    "INSERT",
-                    "INSERT OR IGNORE",
-                    "one"
-                );
-            }
+    /**
+     * Compile a Builder's query into an insert string.
+     *
+     * @query The Builder instance.
+     * @columns The array of columns into which to insert.
+     * @values The array of values to insert.
+     *
+     * @return string
+     */
+    public string function compileInsert( required QueryBuilder query, required array columns, required array values ) {
+        var returningColumns = query
+            .getReturning()
+            .map( wrapColumn )
+            .toList( ", " );
+        var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+        return super.compileInsert( argumentCollection = arguments ) & returningClause;
+    }
 
-            /**
-             * Compile a Builder's query into an update string.
-             *
-             * @query The Builder instance.
-             * @columns The array of columns into which to insert.
-             *
-             * @return string
-             */
-            public string function compileUpdate(
-                required QueryBuilder query,
-                required array columns,
-                required struct updateMap
-            ) {
-                var updateList = columns
-                    .map( function( column ) {
-                        var value = updateMap[ column.original ];
-                        var assignment = "?";
-                        if ( utils.isExpression( value ) ) {
-                            assignment = value.getSql();
-                        } else if ( utils.isBuilder( value ) ) {
-                            assignment = "(#value.toSQL()#)";
-                        }
-                        return "#wrapColumn( column.formatted )# = #assignment#";
-                    } )
-                    .toList( ", " );
+    /**
+     * Compile a Builder's query into an insert string ignoring duplicate key values.
+     *
+     * @qb The Builder instance.
+     * @columns The array of columns into which to insert.
+     * @target The array of key columns to match.
+     * @values The array of values to insert.
+     *
+     * @return string
+     */
+    public string function compileInsertIgnore(
+        required QueryBuilder qb,
+        required array columns,
+        required array target,
+        required array values
+    ) {
+        return replace(
+            compileInsert( arguments.qb, arguments.columns, arguments.values ),
+            "INSERT",
+            "INSERT OR IGNORE",
+            "one"
+        );
+    }
 
-                var updateStatement = "UPDATE #wrapTable( query.getFrom() )#";
-                var joinStatement = "";
-                if ( !arguments.query.getJoins().isEmpty() ) {
-                    joinStatement = " FROM #wrapTable( query.getFrom() )# " & compileJoins( arguments.query, arguments.query.getJoins() );
+    /**
+     * Compile a Builder's query into an update string.
+     *
+     * @query The Builder instance.
+     * @columns The array of columns into which to insert.
+     *
+     * @return string
+     */
+    public string function compileUpdate(
+        required QueryBuilder query,
+        required array columns,
+        required struct updateMap
+    ) {
+        var updateList = columns
+            .map( function( column ) {
+                var value = updateMap[ column.original ];
+                var assignment = "?";
+                if ( utils.isExpression( value ) ) {
+                    assignment = value.getSql();
+                } else if ( utils.isBuilder( value ) ) {
+                    assignment = "(#value.toSQL()#)";
                 }
+                return "#wrapColumn( column.formatted )# = #assignment#";
+            } )
+            .toList( ", " );
 
-                return trim(
-                    updateStatement & " SET #updateList##joinStatement# #compileWheres( query, query.getWheres() )# #compileLimitValue( query, query.getLimitValue() )#"
-                );
-            }
+        var updateStatement = "UPDATE #wrapTable( query.getFrom() )#";
+        var joinStatement = "";
+        if ( !arguments.query.getJoins().isEmpty() ) {
+            joinStatement = " FROM #wrapTable( query.getFrom() )# " & compileJoins(
+                arguments.query,
+                arguments.query.getJoins()
+            );
+        }
 
-            public string function compileUpsert(
-                required QueryBuilder qb,
-                required array insertColumns,
-                required array values,
-                required array updateColumns,
-                required any updates,
-                required array target,
-                QueryBuilder source,
-                boolean deleteUnmatched = false
-            ) {
-                if ( arguments.deleteUnmatched ) {
-                    throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
-                }
+        return trim(
+            updateStatement & " SET #updateList##joinStatement# #compileWheres( query, query.getWheres() )# #compileLimitValue( query, query.getLimitValue() )#"
+        );
+    }
 
-                var insertString = isNull( arguments.source ) ? this.compileInsert(
-                    arguments.qb,
-                    arguments.insertColumns,
-                    arguments.values
-                ) : this.compileInsertUsing( arguments.qb, arguments.insertColumns, arguments.source );
-                var updateString = "";
-                if ( isArray( arguments.updates ) ) {
-                    updateString = arguments.updateColumns
-                        .map( function( column ) {
-                            return "#wrapValue( column.formatted )# = EXCLUDED.#wrapValue( column.formatted )#";
-                        } )
-                        .toList( ", " );
-                } else {
-                    updateString = arguments.updateColumns
-                        .map( function( column ) {
-                            var value = updates[ column.original ];
-                            return "#wrapValue( column.formatted )# = #getUtils().isExpression( value ) ? value.getSQL() : "?"#";
-                        } )
-                        .toList( ", " );
-                }
+    public string function compileUpsert(
+        required QueryBuilder qb,
+        required array insertColumns,
+        required array values,
+        required array updateColumns,
+        required any updates,
+        required array target,
+        QueryBuilder source,
+        boolean deleteUnmatched = false
+    ) {
+        if ( arguments.deleteUnmatched ) {
+            throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
+        }
 
-                var constraintString = arguments.target
-                    .map( function( column ) {
-                        return wrapColumn( column.formatted );
-                    } )
-                    .toList( ", " );
+        var insertString = isNull( arguments.source ) ? this.compileInsert(
+            arguments.qb,
+            arguments.insertColumns,
+            arguments.values
+        ) : this.compileInsertUsing( arguments.qb, arguments.insertColumns, arguments.source );
+        var updateString = "";
+        if ( isArray( arguments.updates ) ) {
+            updateString = arguments.updateColumns
+                .map( function( column ) {
+                    return "#wrapValue( column.formatted )# = EXCLUDED.#wrapValue( column.formatted )#";
+                } )
+                .toList( ", " );
+        } else {
+            updateString = arguments.updateColumns
+                .map( function( column ) {
+                    var value = updates[ column.original ];
+                    return "#wrapValue( column.formatted )# = #getUtils().isExpression( value ) ? value.getSQL() : "?"#";
+                } )
+                .toList( ", " );
+        }
 
-                var returningColumns = arguments.qb
-                    .getReturning()
-                    .map( wrapColumn )
-                    .toList( ", " );
-                var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+        var constraintString = arguments.target
+            .map( function( column ) {
+                return wrapColumn( column.formatted );
+            } )
+            .toList( ", " );
 
-                return insertString & " ON CONFLICT (#constraintString#) DO UPDATE SET #updateString##returningClause#";
-            }
-            
-            public string function compileConcat( required string alias, required array items ) {
-                return "#arrayToList( items, " || " )# AS #wrapAlias( alias )#";
-            }
+        var returningColumns = arguments.qb
+            .getReturning()
+            .map( wrapColumn )
+            .toList( ", " );
+        var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+
+        return insertString & " ON CONFLICT (#constraintString#) DO UPDATE SET #updateString##returningClause#";
+    }
+
+    public string function compileConcat( required string alias, required array items ) {
+        return "#arrayToList( items, " || " )# AS #wrapAlias( alias )#";
+    }
 
     /*=====  End of Query Builder  ======*/
 
@@ -191,108 +194,105 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =           Column Types            =
     ===================================*/
 
-        function wrapDefaultType( column ) {
-            switch ( column.getType() ) {
-                case "boolean":
-                    return column.getDefault() ? 1 : 0;
-                case "char":
-                case "string":
-                    return "'#column.getDefault()#'";
-                default:
-                    return column.getDefault();
-            }
+    function wrapDefaultType( column ) {
+        switch ( column.getType() ) {
+            case "boolean":
+                return column.getDefault() ? 1 : 0;
+            case "char":
+            case "string":
+                return "'#column.getDefault()#'";
+            default:
+                return column.getDefault();
         }
+    }
 
-        function typeString( column ) {
-            return "TEXT";
-        }
+    function typeString( column ) {
+        return "TEXT";
+    }
 
-        function typeUnicodeString( column ) {
-            return typeString( argumentCollection = arguments );
-        }
+    function typeUnicodeString( column ) {
+        return typeString( argumentCollection = arguments );
+    }
 
-        function typeBigInteger( column ) {
-
-            if ( column.getAutoIncrement() ) {
-                return "INTEGER";
-            }
-
-            return "BIGINT";
-        }
-
-        function typeSmallInteger( column ) {
-
-            if ( column.getAutoIncrement() ) {
-                return "INTEGER";
-            }
-
-            return "SMALLINT";
-        }
-
-        function typeInteger( column ) {
+    function typeBigInteger( column ) {
+        if ( column.getAutoIncrement() ) {
             return "INTEGER";
         }
 
-        function typeMediumInteger( column ) {
+        return "BIGINT";
+    }
 
-            if ( column.getAutoIncrement() ) {
-                return "INTEGER";
-            }
-
-            return "MEDIUMINT";
+    function typeSmallInteger( column ) {
+        if ( column.getAutoIncrement() ) {
+            return "INTEGER";
         }
 
-        function modifyUnsigned( column ) {
-            return "";
+        return "SMALLINT";
+    }
+
+    function typeInteger( column ) {
+        return "INTEGER";
+    }
+
+    function typeMediumInteger( column ) {
+        if ( column.getAutoIncrement() ) {
+            return "INTEGER";
         }
 
-        function typeBit( column ) {
-            return "BOOLEAN";
+        return "MEDIUMINT";
+    }
+
+    function modifyUnsigned( column ) {
+        return "";
+    }
+
+    function typeBit( column ) {
+        return "BOOLEAN";
+    }
+
+    function typeBoolean( column ) {
+        return "BOOLEAN";
+    }
+
+    function typeChar( column ) {
+        return "VARCHAR(#column.getLength()#)";
+    }
+
+    function typeEnum( column, blueprint ) {
+        return "TEXT";
+    }
+
+    function typeLineString( column, blueprint ) {
+        return "TEXT";
+    }
+
+    function typePoint( column ) {
+        return "TEXT";
+    }
+
+    function typePolygon( column ) {
+        return "TEXT";
+    }
+
+    function typeTime( column ) {
+        return "TEXT";
+    }
+
+    function typeTimeTz( column ) {
+        return "TEXT";
+    }
+
+    function typeTimestamp( column ) {
+        return "TEXT";
+    }
+
+    function typeTinyInteger( column ) {
+        if ( column.getAutoIncrement() ) {
+            return "INTEGER";
         }
 
-        function typeBoolean( column ) {
-            return "BOOLEAN";
-        }
-
-        function typeChar( column ) {
-            return "VARCHAR(#column.getLength()#)";
-        }
-
-        function typeEnum( column, blueprint ) {
-            return "TEXT";
-        }
-
-        function typeLineString( column, blueprint ) {
-            return "TEXT";
-        }
-
-        function typePoint( column ) {
-            return "TEXT";
-        }
-
-        function typePolygon( column ) {
-            return "TEXT";
-        }
-
-        function typeTime( column ) {
-            return "TEXT";
-        }
-
-        function typeTimeTz( column ) {
-            return "TEXT";
-        }
-
-        function typeTimestamp( column ) {
-            return "TEXT";
-        }
-
-        function typeTinyInteger( column ) {
-            if ( column.getAutoIncrement() ) {
-                return "INTEGER";
-            }
-
-            RETURN "TINYINT";
-        }
+        RETURN"TINYINT";
+    }
 
 
 
@@ -303,54 +303,57 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =            Blueprint: Create            =
     =========================================*/
 
-        function generateAutoIncrement( column, blueprint ) {
-
-            //SQLite does not allow the primary key defined as a constraint when using autoincrement
-            if ( column.getAutoIncrement() ) {
-                blueprint.setIndexes( blueprint.getIndexes().filter(function(index) {
-                    return index.getType() != "primary";
-                }) );
-            }
-            return column.getAutoIncrement() ? "PRIMARY KEY AUTOINCREMENT" : "";
-        }
-
-        function generateUniqueConstraint( column, blueprint ) {
-            //SQLite does not have an enum type so we add an CHECK constraint to enforce specific values
-            if ( column.getType() == "enum" ) {
-                var values = column
-                    .getValues()
-                    .map( function( value ) {
-                        return "'#value#'";
+    function generateAutoIncrement( column, blueprint ) {
+        // SQLite does not allow the primary key defined as a constraint when using autoincrement
+        if ( column.getAutoIncrement() ) {
+            blueprint.setIndexes(
+                blueprint
+                    .getIndexes()
+                    .filter( function( index ) {
+                        return index.getType() != "primary";
                     } )
-                    .toList( ", " );
-                return "CHECK (#wrapColumn(column.getName())# IN (#values#))";
+            );
+        }
+        return column.getAutoIncrement() ? "PRIMARY KEY AUTOINCREMENT" : "";
+    }
+
+    function generateUniqueConstraint( column, blueprint ) {
+        // SQLite does not have an enum type so we add an CHECK constraint to enforce specific values
+        if ( column.getType() == "enum" ) {
+            var values = column
+                .getValues()
+                .map( function( value ) {
+                    return "'#value#'";
+                } )
+                .toList( ", " );
+            return "CHECK (#wrapColumn( column.getName() )# IN (#values#))";
+        }
+
+        return column.getUnique() ? "UNIQUE" : "";
+    }
+
+    function generateDefault( column ) {
+        if (
+            column.getDefault() == "" &&
+            column.getType().findNoCase( "TIMESTAMP" ) > 0
+        ) {
+            if ( column.getNullable() ) {
+                return "";
+            } else {
+                column.withCurrent();
             }
-
-            return column.getUnique() ? "UNIQUE" : "";
         }
+        return super.generateDefault( column );
+    }
 
-        function generateDefault( column ) {
-            if (
-                column.getDefault() == "" &&
-                column.getType().findNoCase( "TIMESTAMP" ) > 0
-            ) {
-                if ( column.getNullable() ) {
-                    return "";
-                } else {
-                    column.withCurrent();
-                }
-            }
-            return super.generateDefault( column );
-        }
+    function indexBasic( index, blueprint ) {
+        blueprint.addCommand( "addIndex", { index: index, table: blueprint.getTable() } );
+        return "";
+    }
 
-        function indexBasic( index, blueprint ) {
-            blueprint.addCommand( "addIndex", { index: index, table: blueprint.getTable() } );
-            return "";
-        }
-
-        function generateComment( column ) {
-            return "";
-        }
+    function generateComment( column ) {
+        return "";
+    }
 
 
     /*=====  End of Blueprint: Create  ======*/
@@ -359,63 +362,73 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =            Blueprint: Alter            =
     ========================================*/
 
-        function compileModifyColumn( blueprint, commandParameters ) {
-            throw( type = "UnsupportedOperation", message = "This grammar does not support modifying columns" );
-        }
+    function compileModifyColumn( blueprint, commandParameters ) {
+        throw( type = "UnsupportedOperation", message = "This grammar does not support modifying columns" );
+    }
 
-        function compileAddColumn( blueprint, commandParameters ) {
-            return arrayToList(
-                arrayFilter(
-                    [
-                        "ALTER TABLE",
-                        wrapTable( blueprint.getTable() ),
-                        "ADD COLUMN",
-                        compileCreateColumn( commandParameters.column, blueprint )
-                    ],
-                    function( item ) {
-                        return item != "";
-                    }
-                ),
-                " "
-            );
-        }
+    function compileAddColumn( blueprint, commandParameters ) {
+        return arrayToList(
+            arrayFilter(
+                [
+                    "ALTER TABLE",
+                    wrapTable( blueprint.getTable() ),
+                    "ADD COLUMN",
+                    compileCreateColumn( commandParameters.column, blueprint )
+                ],
+                function( item ) {
+                    return item != "";
+                }
+            ),
+            " "
+        );
+    }
 
-        function compileAddConstraint( blueprint, commandParameters ) {
-            var index = commandParameters.index;
-            var constraint = invoke( this, "index#index.getType()#", { index: index, isAlter: true, tableName: blueprint.getTable() } );
-            return "#constraint#";
-        }
+    function compileAddConstraint( blueprint, commandParameters ) {
+        var index = commandParameters.index;
+        var constraint = invoke(
+            this,
+            "index#index.getType()#",
+            { index: index, isAlter: true, tableName: blueprint.getTable() }
+        );
+        return "#constraint#";
+    }
 
-        function compileRenameConstraint( blueprint, commandParameters ) {
-            throw( type = "UnsupportedOperation", message = "This grammar does not support renaming constraints. You can drop it and add a new one with a different name." );
-        }
+    function compileRenameConstraint( blueprint, commandParameters ) {
+        throw(
+            type = "UnsupportedOperation",
+            message = "This grammar does not support renaming constraints. You can drop it and add a new one with a different name."
+        );
+    }
 
-        function compileDropConstraint( blueprint, commandParameters ) {
-            return "DROP INDEX #wrapValue( commandParameters.name )#";
-        }
+    function compileDropConstraint( blueprint, commandParameters ) {
+        return "DROP INDEX #wrapValue( commandParameters.name )#";
+    }
 
-        function compileDropForeignKey( blueprint, commandParameters ) {
-            throw( type = "UnsupportedOperation", message = "This grammar does not support droping foreign keys constraints." );
-        }
+    function compileDropForeignKey( blueprint, commandParameters ) {
+        throw(
+            type = "UnsupportedOperation",
+            message = "This grammar does not support droping foreign keys constraints."
+        );
+    }
 
-        function compileRenameColumn( blueprint, commandParameters ) {
-            return arrayToList(
-                arrayFilter(
-                    [
-                        "ALTER TABLE",
-                        wrapTable( blueprint.getTable() ),
-                        "RENAME COLUMN",
-                        wrapColumn( commandParameters.from ),
-                        "TO",
-                        wrapColumn( commandParameters.to.getName() )
-                    ],
-                    function( item ) {
-                        return item != "";
-                    }
-                ),
-                " "
-            );
-        }
+    function compileRenameColumn( blueprint, commandParameters ) {
+        return arrayToList(
+            arrayFilter(
+                [
+                    "ALTER TABLE",
+                    wrapTable( blueprint.getTable() ),
+                    "RENAME COLUMN",
+                    wrapColumn( commandParameters.from ),
+                    "TO",
+                    wrapColumn( commandParameters.to.getName() )
+                ],
+                function( item ) {
+                    return item != "";
+                }
+            ),
+            " "
+        );
+    }
 
     /*=====  End of Blueprint: Alter  ======*/
 
@@ -423,28 +436,26 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =            Blueprint: Drop            =
     =======================================*/
 
-        function compileTableExists( tableName, schemaName = "" ) {
-            var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# WHERE #wrapColumn( "type" )# = 'table' AND #wrapColumn( "name" )# = ?";
+    function compileTableExists( tableName, schemaName = "" ) {
+        var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# WHERE #wrapColumn( "type" )# = 'table' AND #wrapColumn( "name" )# = ?";
 
-            if ( schemaName != "" ) {
-                sql &= " AND #wrapColumn( "schema" )# = ?";
-            }
-            else {
-                sql &= " AND #wrapColumn( "schema" )# = 'main'";
-            }
-            return sql;
+        if ( schemaName != "" ) {
+            sql &= " AND #wrapColumn( "schema" )# = ?";
+        } else {
+            sql &= " AND #wrapColumn( "schema" )# = 'main'";
         }
+        return sql;
+    }
 
-        function compileColumnExists( table, column, schema = "" ) {
-            var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# tl JOIN pragma_table_info(tl.name) ti WHERE tl.#wrapColumn( "type" )# = 'table' AND tl.#wrapColumn( "name" )# = ? AND ti.#wrapColumn( "name" )# = ?";
-            if ( schema != "" ) {
-                sql &= " AND tl.#wrapColumn( "schema" )# = ?";
-            }
-            else {
-                sql &= " AND tl.#wrapColumn( "schema" )# = 'main'";
-            }
-            return sql;
+    function compileColumnExists( table, column, schema = "" ) {
+        var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# tl JOIN pragma_table_info(tl.name) ti WHERE tl.#wrapColumn( "type" )# = 'table' AND tl.#wrapColumn( "name" )# = ? AND ti.#wrapColumn( "name" )# = ?";
+        if ( schema != "" ) {
+            sql &= " AND tl.#wrapColumn( "schema" )# = ?";
+        } else {
+            sql &= " AND tl.#wrapColumn( "schema" )# = 'main'";
         }
+        return sql;
+    }
 
     /*=====  End of Blueprint: Drop  ======*/
 
@@ -452,57 +463,55 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =            Index Types            =
     ===================================*/
 
-        function indexUnique( index, tableName, isAlter = false ) {
-            var references = index
-                .getColumns()
-                .map( function( column ) {
-                    return wrapColumn( column );
-                } )
-                .toList( ", " );
+    function indexUnique( index, tableName, isAlter = false ) {
+        var references = index
+            .getColumns()
+            .map( function( column ) {
+                return wrapColumn( column );
+            } )
+            .toList( ", " );
 
-            if ( isAlter ) {
-                return "CREATE UNIQUE INDEX #wrapValue( index.getName() )# ON #wrapTable( tableName )#(#references#)";
-            }
-            else {
-                return "CONSTRAINT #wrapValue( index.getName() )# UNIQUE (#references#)";
-            }
-
+        if ( isAlter ) {
+            return "CREATE UNIQUE INDEX #wrapValue( index.getName() )# ON #wrapTable( tableName )#(#references#)";
+        } else {
+            return "CONSTRAINT #wrapValue( index.getName() )# UNIQUE (#references#)";
         }
+    }
 
-        function indexPrimary( index ) {
-            var references = index
-                .getColumns()
-                .map( function( column ) {
-                    return wrapColumn( column );
-                } )
-                .toList( ", " );
-            return "PRIMARY KEY (#references#)";
-        }
+    function indexPrimary( index ) {
+        var references = index
+            .getColumns()
+            .map( function( column ) {
+                return wrapColumn( column );
+            } )
+            .toList( ", " );
+        return "PRIMARY KEY (#references#)";
+    }
 
-        function indexForeign( index ) {
-            // FOREIGN KEY ("country_id") REFERENCES countries ("id") ON DELETE CASCADE
-            var keys = index
-                .getForeignKey()
-                .map( function( key ) {
-                    return wrapColumn( key );
-                } )
-                .toList( ", " );
-            var references = index
-                .getColumns()
-                .map( function( column ) {
-                    return wrapColumn( column );
-                } )
-                .toList( ", " );
-            return arrayToList(
-                [
-                    "FOREIGN KEY (#keys#)",
-                    "REFERENCES #wrapTable( index.getTable() )# (#references#)",
-                    "ON UPDATE #uCase( index.getOnUpdate() )#",
-                    "ON DELETE #uCase( index.getOnDelete() )#"
-                ],
-                " "
-            );
-        }
+    function indexForeign( index ) {
+        // FOREIGN KEY ("country_id") REFERENCES countries ("id") ON DELETE CASCADE
+        var keys = index
+            .getForeignKey()
+            .map( function( key ) {
+                return wrapColumn( key );
+            } )
+            .toList( ", " );
+        var references = index
+            .getColumns()
+            .map( function( column ) {
+                return wrapColumn( column );
+            } )
+            .toList( ", " );
+        return arrayToList(
+            [
+                "FOREIGN KEY (#keys#)",
+                "REFERENCES #wrapTable( index.getTable() )# (#references#)",
+                "ON UPDATE #uCase( index.getOnUpdate() )#",
+                "ON DELETE #uCase( index.getOnDelete() )#"
+            ],
+            " "
+        );
+    }
 
     /*=====  End of Index Types  ======*/
 
@@ -510,12 +519,11 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =               Views               =
     ===================================*/
 
-        function compileCreateView( blueprint, commandParameters ) {
-            var query = commandParameters[ "query" ];
-            return "CREATE VIEW #wrapTable( blueprint.getTable() )# AS #compileSelect( query )#";
-        }
+    function compileCreateView( blueprint, commandParameters ) {
+        var query = commandParameters[ "query" ];
+        return "CREATE VIEW #wrapTable( blueprint.getTable() )# AS #compileSelect( query )#";
+    }
 
     /*=====  End of Views  ======*/
-
 
 }

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -1,0 +1,521 @@
+component extends="qb.models.Grammars.BaseGrammar" singleton {
+
+    /**
+     * Creates a new SQLite Query Grammar.
+     *
+     * @utils A collection of query utilities. Default: qb.models.Query.QueryUtils
+     *
+     * @return qb.models.Grammars.SQLiteGrammar
+     */
+    public SQLiteGrammar function init( qb.models.Query.QueryUtils utils ) {
+        super.init( argumentCollection = arguments );
+
+        variables.cteColumnsRequireParentheses = true;
+
+        return this;
+    }
+
+    /*===================================
+    =           Query Builder           =
+    ===================================*/
+
+        /**
+         * Compiles the lock portion of a sql statement.
+         *
+         * @query The Builder instance.
+         * @lockType The lock type to compile.
+         *
+         * @return string
+         */
+        private string function compileLockType( required query, required string lockType ) {
+            return "";
+        }
+
+        /**
+         * Compiles the offset portion of a sql statement.
+         *
+         * @query The Builder instance.
+         * @offsetValue The offset value.
+         *
+         * @return string
+         */
+        private string function compileOffsetValue( required QueryBuilder query, offsetValue ) {
+            if ( isNull( arguments.offsetValue ) ) {
+                return "";
+            }
+
+            //SQLite requires LIMIT when using OFFSET. A negative integer means no limit
+            if ( isNull( query.getLimitValue() ) ) {
+                return "LIMIT -1 OFFSET #offsetValue#";
+            }
+
+            return "OFFSET #offsetValue#";
+        }
+
+            /**
+             * Compile a Builder's query into an insert string.
+             *
+             * @query The Builder instance.
+             * @columns The array of columns into which to insert.
+             * @values The array of values to insert.
+             *
+             * @return string
+             */
+            public string function compileInsert( required QueryBuilder query, required array columns, required array values ) {
+                var returningColumns = query
+                    .getReturning()
+                    .map( wrapColumn )
+                    .toList( ", " );
+                var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+                return super.compileInsert( argumentCollection = arguments ) & returningClause;
+            }
+
+            /**
+             * Compile a Builder's query into an insert string ignoring duplicate key values.
+             *
+             * @qb The Builder instance.
+             * @columns The array of columns into which to insert.
+             * @target The array of key columns to match.
+             * @values The array of values to insert.
+             *
+             * @return string
+             */
+            public string function compileInsertIgnore(
+                required QueryBuilder qb,
+                required array columns,
+                required array target,
+                required array values
+            ) {
+                return replace(
+                    compileInsert( arguments.qb, arguments.columns, arguments.values ),
+                    "INSERT",
+                    "INSERT OR IGNORE",
+                    "one"
+                );
+            }
+
+            /**
+             * Compile a Builder's query into an update string.
+             *
+             * @query The Builder instance.
+             * @columns The array of columns into which to insert.
+             *
+             * @return string
+             */
+            public string function compileUpdate(
+                required QueryBuilder query,
+                required array columns,
+                required struct updateMap
+            ) {
+                var updateList = columns
+                    .map( function( column ) {
+                        var value = updateMap[ column.original ];
+                        var assignment = "?";
+                        if ( utils.isExpression( value ) ) {
+                            assignment = value.getSql();
+                        } else if ( utils.isBuilder( value ) ) {
+                            assignment = "(#value.toSQL()#)";
+                        }
+                        return "#wrapColumn( column.formatted )# = #assignment#";
+                    } )
+                    .toList( ", " );
+
+                var updateStatement = "UPDATE #wrapTable( query.getFrom() )#";
+                var joinStatement = "";
+                if ( !arguments.query.getJoins().isEmpty() ) {
+                    joinStatement = " FROM #wrapTable( query.getFrom() )# " & compileJoins( arguments.query, arguments.query.getJoins() );
+                }
+
+                return trim(
+                    updateStatement & " SET #updateList##joinStatement# #compileWheres( query, query.getWheres() )# #compileLimitValue( query, query.getLimitValue() )#"
+                );
+            }
+
+            public string function compileUpsert(
+                required QueryBuilder qb,
+                required array insertColumns,
+                required array values,
+                required array updateColumns,
+                required any updates,
+                required array target,
+                QueryBuilder source,
+                boolean deleteUnmatched = false
+            ) {
+                if ( arguments.deleteUnmatched ) {
+                    throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
+                }
+
+                var insertString = isNull( arguments.source ) ? this.compileInsert(
+                    arguments.qb,
+                    arguments.insertColumns,
+                    arguments.values
+                ) : this.compileInsertUsing( arguments.qb, arguments.insertColumns, arguments.source );
+                var updateString = "";
+                if ( isArray( arguments.updates ) ) {
+                    updateString = arguments.updateColumns
+                        .map( function( column ) {
+                            return "#wrapValue( column.formatted )# = EXCLUDED.#wrapValue( column.formatted )#";
+                        } )
+                        .toList( ", " );
+                } else {
+                    updateString = arguments.updateColumns
+                        .map( function( column ) {
+                            var value = updates[ column.original ];
+                            return "#wrapValue( column.formatted )# = #getUtils().isExpression( value ) ? value.getSQL() : "?"#";
+                        } )
+                        .toList( ", " );
+                }
+
+                var constraintString = arguments.target
+                    .map( function( column ) {
+                        return wrapColumn( column.formatted );
+                    } )
+                    .toList( ", " );
+
+                var returningColumns = arguments.qb
+                    .getReturning()
+                    .map( wrapColumn )
+                    .toList( ", " );
+                var returningClause = returningColumns != "" ? " RETURNING #returningColumns#" : "";
+
+                return insertString & " ON CONFLICT (#constraintString#) DO UPDATE SET #updateString##returningClause#";
+            }
+            
+            public string function compileConcat( required string alias, required array items ) {
+                return "#arrayToList( items, " || " )# AS #wrapAlias( alias )#";
+            }
+
+    /*=====  End of Query Builder  ======*/
+
+    /*===================================
+    =           Column Types            =
+    ===================================*/
+
+        function wrapDefaultType( column ) {
+            switch ( column.getType() ) {
+                case "boolean":
+                    return column.getDefault() ? 1 : 0;
+                case "char":
+                case "string":
+                    return "'#column.getDefault()#'";
+                default:
+                    return column.getDefault();
+            }
+        }
+
+        function typeString( column ) {
+            return "TEXT";
+        }
+
+        function typeUnicodeString( column ) {
+            return typeString( argumentCollection = arguments );
+        }
+
+        function typeBigInteger( column ) {
+
+            if ( column.getAutoIncrement() ) {
+                return "INTEGER";
+            }
+
+            return "BIGINT";
+        }
+
+        function typeSmallInteger( column ) {
+
+            if ( column.getAutoIncrement() ) {
+                return "INTEGER";
+            }
+
+            return "SMALLINT";
+        }
+
+        function typeInteger( column ) {
+            return "INTEGER";
+        }
+
+        function typeMediumInteger( column ) {
+
+            if ( column.getAutoIncrement() ) {
+                return "INTEGER";
+            }
+
+            return "MEDIUMINT";
+        }
+
+        function modifyUnsigned( column ) {
+            return "";
+        }
+
+        function typeBit( column ) {
+            return "BOOLEAN";
+        }
+
+        function typeBoolean( column ) {
+            return "BOOLEAN";
+        }
+
+        function typeChar( column ) {
+            return "VARCHAR(#column.getLength()#)";
+        }
+
+        function typeEnum( column, blueprint ) {
+            return "TEXT";
+        }
+
+        function typeLineString( column, blueprint ) {
+            return "TEXT";
+        }
+
+        function typePoint( column ) {
+            return "TEXT";
+        }
+
+        function typePolygon( column ) {
+            return "TEXT";
+        }
+
+        function typeTime( column ) {
+            return "TEXT";
+        }
+
+        function typeTimeTz( column ) {
+            return "TEXT";
+        }
+
+        function typeTimestamp( column ) {
+            return "TEXT";
+        }
+
+        function typeTinyInteger( column ) {
+            if ( column.getAutoIncrement() ) {
+                return "INTEGER";
+            }
+
+            RETURN "TINYINT";
+        }
+
+
+
+
+    /*=====  End of Column Types  ======*/
+
+    /*=========================================
+    =            Blueprint: Create            =
+    =========================================*/
+
+        function generateAutoIncrement( column, blueprint ) {
+
+            //SQLite does not allow the primary key defined as a constraint when using autoincrement
+            if ( column.getAutoIncrement() ) {
+                blueprint.setIndexes( blueprint.getIndexes().filter(function(index) {
+                    return index.getType() != "primary";
+                }) );
+            }
+            return column.getAutoIncrement() ? "PRIMARY KEY AUTOINCREMENT" : "";
+        }
+
+        function generateUniqueConstraint( column, blueprint ) {
+            //SQLite does not have an enum type so we add an CHECK constraint to enforce specific values
+            if ( column.getType() == "enum" ) {
+                var values = column
+                    .getValues()
+                    .map( function( value ) {
+                        return "'#value#'";
+                    } )
+                    .toList( ", " );
+                return "CHECK (#wrapColumn(column.getName())# IN (#values#))";
+            }
+
+            return column.getUnique() ? "UNIQUE" : "";
+        }
+
+        function generateDefault( column ) {
+            if (
+                column.getDefault() == "" &&
+                column.getType().findNoCase( "TIMESTAMP" ) > 0
+            ) {
+                if ( column.getNullable() ) {
+                    return "";
+                } else {
+                    column.withCurrent();
+                }
+            }
+            return super.generateDefault( column );
+        }
+
+        function indexBasic( index, blueprint ) {
+            blueprint.addCommand( "addIndex", { index: index, table: blueprint.getTable() } );
+            return "";
+        }
+
+        function generateComment( column ) {
+            return "";
+        }
+
+
+    /*=====  End of Blueprint: Create  ======*/
+
+    /*========================================
+    =            Blueprint: Alter            =
+    ========================================*/
+
+        function compileModifyColumn( blueprint, commandParameters ) {
+            throw( type = "UnsupportedOperation", message = "This grammar does not support modifying columns" );
+        }
+
+        function compileAddColumn( blueprint, commandParameters ) {
+            return arrayToList(
+                arrayFilter(
+                    [
+                        "ALTER TABLE",
+                        wrapTable( blueprint.getTable() ),
+                        "ADD COLUMN",
+                        compileCreateColumn( commandParameters.column, blueprint )
+                    ],
+                    function( item ) {
+                        return item != "";
+                    }
+                ),
+                " "
+            );
+        }
+
+        function compileAddConstraint( blueprint, commandParameters ) {
+            var index = commandParameters.index;
+            var constraint = invoke( this, "index#index.getType()#", { index: index, isAlter: true, tableName: blueprint.getTable() } );
+            return "#constraint#";
+        }
+
+        function compileRenameConstraint( blueprint, commandParameters ) {
+            throw( type = "UnsupportedOperation", message = "This grammar does not support renaming constraints. You can drop it and add a new one with a different name." );
+        }
+
+        function compileDropConstraint( blueprint, commandParameters ) {
+            return "DROP INDEX #wrapValue( commandParameters.name )#";
+        }
+
+        function compileDropForeignKey( blueprint, commandParameters ) {
+            throw( type = "UnsupportedOperation", message = "This grammar does not support droping foreign keys constraints." );
+        }
+
+        function compileRenameColumn( blueprint, commandParameters ) {
+            return arrayToList(
+                arrayFilter(
+                    [
+                        "ALTER TABLE",
+                        wrapTable( blueprint.getTable() ),
+                        "RENAME COLUMN",
+                        wrapColumn( commandParameters.from ),
+                        "TO",
+                        wrapColumn( commandParameters.to.getName() )
+                    ],
+                    function( item ) {
+                        return item != "";
+                    }
+                ),
+                " "
+            );
+        }
+
+    /*=====  End of Blueprint: Alter  ======*/
+
+    /*=======================================
+    =            Blueprint: Drop            =
+    =======================================*/
+
+        function compileTableExists( tableName, schemaName = "" ) {
+            var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# WHERE #wrapColumn( "type" )# = 'table' AND #wrapColumn( "name" )# = ?";
+
+            if ( schemaName != "" ) {
+                sql &= " AND #wrapColumn( "schema" )# = ?";
+            }
+            else {
+                sql &= " AND #wrapColumn( "schema" )# = 'main'";
+            }
+            return sql;
+        }
+
+        function compileColumnExists( table, column, schema = "" ) {
+            var sql = "SELECT 1 FROM #wrapTable( "pragma_table_list" )# tl JOIN pragma_table_info(tl.name) ti WHERE tl.#wrapColumn( "type" )# = 'table' AND tl.#wrapColumn( "name" )# = ? AND ti.#wrapColumn( "name" )# = ?";
+            if ( schema != "" ) {
+                sql &= " AND tl.#wrapColumn( "schema" )# = ?";
+            }
+            else {
+                sql &= " AND tl.#wrapColumn( "schema" )# = 'main'";
+            }
+            return sql;
+        }
+
+    /*=====  End of Blueprint: Drop  ======*/
+
+    /*===================================
+    =            Index Types            =
+    ===================================*/
+
+        function indexUnique( index, tableName, isAlter = false ) {
+            var references = index
+                .getColumns()
+                .map( function( column ) {
+                    return wrapColumn( column );
+                } )
+                .toList( ", " );
+
+            if ( isAlter ) {
+                return "CREATE UNIQUE INDEX #wrapValue( index.getName() )# ON #wrapTable( tableName )#(#references#)";
+            }
+            else {
+                return "CONSTRAINT #wrapValue( index.getName() )# UNIQUE (#references#)";
+            }
+
+        }
+
+        function indexPrimary( index ) {
+            var references = index
+                .getColumns()
+                .map( function( column ) {
+                    return wrapColumn( column );
+                } )
+                .toList( ", " );
+            return "PRIMARY KEY (#references#)";
+        }
+
+        function indexForeign( index ) {
+            // FOREIGN KEY ("country_id") REFERENCES countries ("id") ON DELETE CASCADE
+            var keys = index
+                .getForeignKey()
+                .map( function( key ) {
+                    return wrapColumn( key );
+                } )
+                .toList( ", " );
+            var references = index
+                .getColumns()
+                .map( function( column ) {
+                    return wrapColumn( column );
+                } )
+                .toList( ", " );
+            return arrayToList(
+                [
+                    "FOREIGN KEY (#keys#)",
+                    "REFERENCES #wrapTable( index.getTable() )# (#references#)",
+                    "ON UPDATE #uCase( index.getOnUpdate() )#",
+                    "ON DELETE #uCase( index.getOnDelete() )#"
+                ],
+                " "
+            );
+        }
+
+    /*=====  End of Index Types  ======*/
+
+    /*===================================
+    =               Views               =
+    ===================================*/
+
+        function compileCreateView( blueprint, commandParameters ) {
+            var query = commandParameters[ "query" ];
+            return "CREATE VIEW #wrapTable( blueprint.getTable() )# AS #compileSelect( query )#";
+        }
+
+    /*=====  End of Views  ======*/
+
+
+}

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -404,6 +404,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "DROP INDEX #wrapValue( commandParameters.name )#";
     }
 
+    function compileDropIndex( blueprint, commandParameters ) {
+        return "DROP INDEX #wrapValue( commandParameters.name )#";
+    }
+
     function compileDropForeignKey( blueprint, commandParameters ) {
         throw(
             type = "UnsupportedOperation",

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -444,6 +444,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return "ALTER TABLE #wrapTable( blueprint.getTable() )# DROP CONSTRAINT #wrapValue( commandParameters.name )#";
     }
 
+    function compileDropIndex( blueprint, commandParameters ) {
+        return "DROP INDEX #wrapTable( blueprint.getTable() )#.#wrapValue( commandParameters.name )#";
+    }
+
     function compileModifyColumn( blueprint, commandParameters ) {
         return arrayToList(
             arrayFilter(

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -528,10 +528,6 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return typeTimestampTz( column );
     }
 
-    function typeUUID( column ) {
-        return "uniqueidentifier";
-    }
-
     function typeEnum( column, blueprint ) {
         blueprint.appendIndex(
             type = "check",
@@ -551,6 +547,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         }
 
         return "FLOAT";
+    }
+
+    function typeGUID( column ) {
+        return "uniqueidentifier";
     }
 
     function typeInteger( column ) {

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3091,10 +3091,24 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @return any
      */
-    public numeric function sum( required string column, struct options = {} ) {
+    public numeric function sum( required any column, struct options = {} ) {
         arguments.type = "sum";
         arguments.defaultValue = 0;
         return aggregateQuery( argumentCollection = arguments );
+    }
+
+    /**
+     * Return the sum of an Expression from a query.
+     * The original query is unaltered by this operation.
+     *
+     * @expression The expression to use to calculate the sum.
+     * @options Any options to pass to `queryExecute`. Default: {}.
+     *
+     * @return any
+     */
+    public numeric function sumRaw( required string expression, struct options = {} ) {
+        arguments.column = raw( arguments.expression );
+        return sum( argumentCollection = arguments );
     }
 
     /**
@@ -3110,7 +3124,7 @@ component displayname="QueryBuilder" accessors="true" {
      */
     private any function aggregateQuery(
         required string type,
-        required string column = "*",
+        required any column = "*",
         struct options = {},
         any defaultValue,
         boolean toSQL = false

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3373,6 +3373,32 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
+     * Retrieve the results of the query in chunks.  The number of items
+     * retrieved at a time is determined by the `max` parameter. Each
+     * chunk of items will be passed to the callback provided.
+     *
+     * @asQuery  Flag to retrieve the columnList as a query instead of an array. Default: false.
+     *
+     * @return   Query | Array<String>
+     */
+    public any function columnList( asQuery = false ) {
+        if ( isNull( getFrom() ) || !isSimpleValue( getFrom() ) || getFrom() == "" ) {
+            throw(
+                type = "MissingTable",
+                message = "A simple table is required to use `columnList`."
+            );
+        }
+
+        cfdbinfo( type = "Columns", name = "local.columnList", table = arguments.table );
+
+        if ( arguments.asQuery ) {
+            return local.columnList;
+        } else {
+            return listToArray( local.columnList.valueList( "column_name" ) );
+        }
+    }
+
+    /**
      * Execute a query and convert it to the proper return format.
      *
      * @sql         The sql string to execute.

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -69,6 +69,12 @@ component displayname="QueryBuilder" accessors="true" {
      */
     property name="defaultOptions";
 
+    /**
+     * The defined SQLCommenter for this builder.
+     * Defaults to a NullSQLCommenter that does nothing.
+     */
+    property name="sqlCommenter";
+
     /******************** Query Properties ********************/
 
     /**
@@ -266,7 +272,8 @@ component displayname="QueryBuilder" accessors="true" {
         paginationCollector = new cbpaginator.models.Pagination(),
         columnFormatter,
         parentQuery,
-        defaultOptions = {}
+        defaultOptions = {},
+        sqlCommenter = new qb.models.SQLCommenter.NullSQLCommenter()
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
@@ -284,6 +291,7 @@ component displayname="QueryBuilder" accessors="true" {
         }
         setDefaultOptions( arguments.defaultOptions );
         setReturnFormat( arguments.returnFormat );
+        setSqlCommenter( arguments.sqlCommenter );
 
         setDefaultValues();
 
@@ -3434,7 +3442,13 @@ component displayname="QueryBuilder" accessors="true" {
     private any function runQuery( required string sql, struct options = {}, string returnObject = "query" ) {
         structAppend( arguments.options, getDefaultOptions(), false );
         var result = grammar.runQuery(
-            sql,
+            variables.sqlCommenter.appendSqlComments(
+                sql,
+                arguments.options.keyExists( "datasource" ) && !isNull( arguments.options.datasource ) ? arguments.options.datasource : javacast(
+                    "null",
+                    ""
+                )
+            ),
             getBindings( except = getAggregate().isEmpty() ? [] : [ "select" ] ),
             arguments.options,
             returnObject

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3379,14 +3379,11 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @asQuery  Flag to retrieve the columnList as a query instead of an array. Default: false.
      *
-     * @return   Query | Array<String>
+     * @return   Query | Array<string>
      */
     public any function columnList( asQuery = false ) {
         if ( isNull( getFrom() ) || !isSimpleValue( getFrom() ) || getFrom() == "" ) {
-            throw(
-                type = "MissingTable",
-                message = "A simple table is required to use `columnList`."
-            );
+            throw( type = "MissingTable", message = "A simple table is required to use `columnList`." );
         }
 
         cfdbinfo( type = "Columns", name = "local.columnList", table = arguments.table );

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3491,6 +3491,22 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
+     * Wraps up items into a CONCAT expression.
+     * This is provided since different engines have different syntax for CONCAT.
+     *
+     * @alias The alias for the CONCAT expression
+     * @items The items in the CONCAT expression, either a list or an array.
+     *
+     * @return qb.models.Query.Expression
+     */
+    public Expression function concat( required string alias, required any items, array bindings = [] ) {
+        return new qb.models.Query.Expression(
+            variables.grammar.compileConcat( arguments.alias, arrayWrap( value = arguments.items, explodeList = true ) ),
+            arguments.bindings
+        );
+    }
+
+    /**
      * Returns the Builder compiled to grammar-specific sql.
      *
      * @return string
@@ -3683,8 +3699,17 @@ component displayname="QueryBuilder" accessors="true" {
      * @doc_generic  any
      * @return       [any]
      */
-    private array function arrayWrap( required any value ) {
-        return isArray( arguments.value ) ? arguments.value : [ arguments.value ];
+    private array function arrayWrap( required any value, boolean explodeList = false ) {
+        if ( isArray( arguments.value ) ) {
+            return arguments.value;
+        }
+
+        if ( arguments.explodeList ) {
+            // this handles lists with or without spaces after the comma
+            return arraySlice( arguments.value.split( ",\s*" ), 1 );
+        } else {
+            return [ arguments.value ];
+        }
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3420,20 +3420,25 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
-     * Retrieve the results of the query in chunks.  The number of items
-     * retrieved at a time is determined by the `max` parameter. Each
-     * chunk of items will be passed to the callback provided.
+     * Retrieves the columns for the configured table.
      *
-     * @asQuery  Flag to retrieve the columnList as a query instead of an array. Default: false.
+     * @asQuery     Flag to retrieve the columnList as a query instead of an array. Default: false.
+     * @datasource  Optional datasource to from which to retrieve the columnList.
      *
-     * @return   Query | Array<string>
+     * @throws      MissingTable
+     *
+     * @return      Query | Array<string>
      */
-    public any function columnList( asQuery = false ) {
+    public any function columnList( boolean asQuery = false, string datasource ) {
         if ( isNull( getFrom() ) || !isSimpleValue( getFrom() ) || getFrom() == "" ) {
             throw( type = "MissingTable", message = "A simple table is required to use `columnList`." );
         }
 
-        cfdbinfo( type = "Columns", name = "local.columnList", table = arguments.table );
+        var attrs = { "type": "Columns", "name": "local.columnList", "table": variables.from };
+        if ( !isNull( arguments.datasource ) ) {
+            attrs[ "datasource" ] = arguments.datasource;
+        }
+        cfdbinfo( attributeCollection = attrs );
 
         if ( arguments.asQuery ) {
             return local.columnList;

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3237,7 +3237,7 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @errorMessage  An optional string error message or callback to produce
      *                a string error message.  If a callback is used, it is
-     *                passed the unloaded entity as the only argument.
+     *                passed the QueryBuilder instance as the only argument.
      *
      * @options Any options to pass to `queryExecute`. Default: {}.
      *

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -6,7 +6,7 @@ component singleton displayname="QueryUtils" accessors="true" {
     /**
      * qb strictDateDetection so we can do some conditional behaviour in data type detections
      */
-    property name="strictDateDetection" default="false";
+    property name="strictDateDetection" default="true";
 
     /**
      * allow overriding default numeric SQL type inferral
@@ -47,7 +47,7 @@ component singleton displayname="QueryUtils" accessors="true" {
      * @return               qb.models.Query.QueryUtils
      */
     public QueryUtils function init(
-        boolean strictDateDetection = false,
+        boolean strictDateDetection = true,
         string numericSQLType = "CF_SQL_NUMERIC",
         boolean autoAddScale = true,
         boolean autoDeriveNumericType = false,

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -50,7 +50,7 @@ component singleton displayname="QueryUtils" accessors="true" {
         boolean strictDateDetection = true,
         string numericSQLType = "CF_SQL_NUMERIC",
         boolean autoAddScale = true,
-        boolean autoDeriveNumericType = false,
+        boolean autoDeriveNumericType = true,
         string integerSqlType = "CF_SQL_INTEGER",
         string decimalSqlType = "CF_SQL_DECIMAL"
     ) {

--- a/models/SQLCommenter/ColdBoxSQLCommenter.cfc
+++ b/models/SQLCommenter/ColdBoxSQLCommenter.cfc
@@ -1,0 +1,54 @@
+component extends="SQLCommenter" singleton {
+
+    /**
+     * All the qb module settings so we can inspect the sqlCommenter settings.
+     */
+    property name="settings" inject="coldbox:moduleSettings:qb";
+
+    /**
+     * WireBox Injector
+     */
+    property name="wirebox" inject="wirebox";
+
+    /**
+     * An array of configured Commenter components.
+     * These are used to fetch the comments for each SQL query.
+     */
+    property name="commenters" type="array";
+
+    /**
+     * Set up the commenters array with configured Commenter components.
+     */
+    function onDIComplete() {
+        variables.commenters = variables.settings.sqlCommenter.commenters.map( ( commenterInfo ) => {
+            param commenterInfo.properties = {};
+            if ( !commenterInfo.keyExists( "class" ) ) {
+                throw( "A commenter must have a class pointing to a WireBox mapping" );
+            }
+
+            return variables.wirebox.getInstance( commenterInfo.class ).setProperties( commenterInfo.properties );
+        } );
+    }
+
+    /**
+     * Gathers comments from the configured commenters and appends it to the SQL query.
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        if ( !settings.sqlCommenter.enabled ) {
+            return arguments.sql;
+        }
+
+        var comments = variables.commenters.reduce( ( acc, commenter ) => {
+            acc.append( commenter.getComments( sql, isNull( datasource ) ? javacast( "null", "" ) : datasource ), true );
+        }, {} );
+
+        return appendCommentsToSQL( arguments.sql, comments );
+    }
+
+}

--- a/models/SQLCommenter/Commenters/DBInfoCommenter.cfc
+++ b/models/SQLCommenter/Commenters/DBInfoCommenter.cfc
@@ -1,0 +1,23 @@
+component singleton accessors="true" {
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        if ( isNull( arguments.datasource ) ) {
+            cfdbinfo( type = "version", name = "local.dbInfo" );
+        } else {
+            cfdbinfo( type = "version", name = "local.dbInfo", datasource = arguments.datasource );
+        }
+
+        return { "dbDriver": dbInfo.DRIVER_VERSION };
+    }
+
+}

--- a/models/SQLCommenter/Commenters/FrameworkCommenter.cfc
+++ b/models/SQLCommenter/Commenters/FrameworkCommenter.cfc
@@ -1,0 +1,19 @@
+component singleton accessors="true" {
+
+    property name="coldboxVersion" inject="coldbox:coldboxSetting:version";
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        return { "version": "coldbox-#variables.coldboxVersion#" };
+    }
+
+}

--- a/models/SQLCommenter/Commenters/ICommenter.cfc
+++ b/models/SQLCommenter/Commenters/ICommenter.cfc
@@ -1,0 +1,17 @@
+interface displayName="ICommenter" {
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource );
+
+    // You can use `accessors="true"` with a `property name="properties";` to implement these methods.
+    public ICommenter function setProperties( required struct properties );
+    public struct function getProperties();
+
+}

--- a/models/SQLCommenter/Commenters/RouteInfoCommenter.cfc.cfc
+++ b/models/SQLCommenter/Commenters/RouteInfoCommenter.cfc.cfc
@@ -1,0 +1,25 @@
+component singleton accessors="true" {
+
+    property name="wirebox" inject="wirebox";
+
+    property name="properties";
+
+    /**
+     * Returns a struct of key/value comment pairs to append to the SQL.
+     *
+     * @sql         The SQL to append the comments to. This is provided if you need to
+     *              inspect the SQL to make any decisions about what comments to return.
+     * @datasource  The datasource that will execute the query. If null, the default datasource will be used.
+     *              This can be used to make decisions about what comments to return.
+     */
+    public struct function getComments( required string sql, string datasource ) {
+        var event = wirebox.getInstance( "coldbox:requestContext" );
+        return {
+            "event": event.getCurrentEvent(),
+            "handler": event.getCurrentHandler(),
+            "action": event.getCurrentAction(),
+            "route": event.getCurrentRoutedURL()
+        };
+    }
+
+}

--- a/models/SQLCommenter/NullSQLCommenter.cfc
+++ b/models/SQLCommenter/NullSQLCommenter.cfc
@@ -1,0 +1,16 @@
+component extends="SQLCommenter" singleton {
+
+    /**
+     * Returns the SQL unchanged for the NullSQLCommenter.
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        return arguments.sql;
+    }
+
+}

--- a/models/SQLCommenter/SQLCommenter.cfc
+++ b/models/SQLCommenter/SQLCommenter.cfc
@@ -1,0 +1,180 @@
+/**
+ * @doc_abstract true
+ */
+component singleton {
+
+    /**
+     * Gathers comments from the configured commenters and appends it to the SQL query.
+     * @doc_abstract true
+     *
+     * @sql         The SQL string to add the comment to.
+     * @datasource  The datasource that will execute the query.
+     *              If null, the default datasource is going to be used.
+     *
+     * @return      Commented SQL string
+     */
+    public string function appendSqlComments( required string sql, string datasource ) {
+        throw( "appendSqlComments is an abstract method and must be implemented in a subclass." );
+    }
+
+    /**
+     * Serializes and appends a struct of key/value comment pairs to the provided SQL string.
+     *
+     * @sql       The SQL string to add the serialized comments to.
+     * @comments  The key/value pairs to serialize and append.
+     *
+     * @return    Commented SQL string
+     */
+    public string function appendCommentsToSQL( required string sql, required struct comments ) {
+        // DO NOT mutate a statement with an already present comment
+        if ( containsSQLComment( arguments.sql ) ) {
+            return arguments.sql;
+        }
+
+        var serializedComments = [];
+        for ( var key in arguments.comments ) {
+            serializedComments.append( serializeComment( key, arguments.comments[ key ] ) );
+        }
+
+        arraySort( serializedComments, "textnocase" )
+
+        return arguments.sql & " /*#arrayToList( serializedComments )#*/";
+    }
+
+    /**
+     * Parses a commented SQL string into the SQL and a struct of the key/value pair comments.
+     *
+     * @sql     The commented SQL string to parse.
+     *
+     * @return  { "sql": string, "comments": struct }
+     */
+    public struct function parseCommentedSQL( required string sql ) {
+        var commentStartPosition = find( "/*", arguments.sql ) - 1;
+        return {
+            "sql": left( arguments.sql, commentStartPosition - 1 ),
+            "comments": parseCommentString(
+                mid( arguments.sql, commentStartPosition + 1, len( arguments.sql ) - commentStartPosition + 1 )
+            )
+        };
+    }
+
+    /**
+     * Parses a comment string into a struct.
+     *
+     * @commentString  The comment string to parse into a struct
+     *
+     * @return         A struct of key/value pairs from the comment.
+     */
+    private struct function parseCommentString( required string commentString ) {
+        arguments.commentString = trim( arguments.commentString );
+        arguments.commentString = replace( arguments.commentString, "/*", "" );
+        arguments.commentString = replace( arguments.commentString, "*/", "" );
+        return listToArray( arguments.commentString ).reduce( ( acc, serializedKeyValuePair ) => {
+            var key = decodeFromURL( unescapeMetaCharacters( listFirst( serializedKeyValuePair, "=" ) ) );
+            var value = decodeFromURL(
+                unescapeMetaCharacters( unescapeSQL( listLast( serializedKeyValuePair, "=" ) ) )
+            );
+            acc[ key ] = value;
+            return acc;
+        }, {} );
+    }
+
+    /**
+     * Returns true if the SQL already contains a comment.
+     *
+     * @sql     The SQL to check for a comment.
+     *
+     * @return  True if the SQL already contains a comment.
+     */
+    private boolean function containsSQLComment( required string sql ) {
+        return find( "--", arguments.sql ) > 0 || find( "/*", arguments.sql ) > 0;
+    }
+
+    /**
+     * Serializes a key/value pair for use in a comment string.
+     *
+     * @key     The key to serialize.
+     * @value   The value to serialize.
+     *
+     * @return  A serialized string for the key/value pair.
+     */
+    private string function serializeComment( required string key, required string value ) {
+        return serializeKey( arguments.key ) & "=" & serializeValue( arguments.value );
+    }
+
+    /**
+     * Serializes a key for use in a comment string.
+     *
+     * @key     The key to serialize.
+     *
+     * @return  The serialized key.
+     */
+    private string function serializeKey( required string key ) {
+        return escapeMetaCharacters( encodeForURL( arguments.key ) );
+    }
+
+    /**
+     * Serializes a value for use in a comment string.
+     *
+     * @value   The value to serialize.
+     *
+     * @return  The serialized value.
+     */
+    private string function serializeValue( required string value ) {
+        return escapeSQL(
+            escapeMetaCharacters(
+                replace(
+                    encodeForURL( arguments.value ),
+                    "+",
+                    "%20",
+                    "all"
+                )
+            )
+        );
+    }
+
+    /**
+     * Escapes meta characters such as single quotes in the passed in string.
+     *
+     * @str     The string to escape meta characters.
+     *
+     * @return  The string with meta characters escaped.
+     */
+    private string function escapeMetaCharacters( required string str ) {
+        return replace( arguments.str, "'", "\'", "all" );
+    }
+
+    /**
+     * Unescapes meta characters such as single quotes in the passed in string.
+     *
+     * @str     The string to unescape meta characters.
+     *
+     * @return  The string without meta characters escaped.
+     */
+    private string function unescapeMetaCharacters( required string str ) {
+        return replace( arguments.str, "\'", "'", "all" );
+    }
+
+    /**
+     * Escapes a string for SQL by surrounding it in single quotes.
+     *
+     * @str      The string to escape for SQL.
+     *
+     * @returns  The string escaped for SQL.
+     */
+    private string function escapeSQL( required string str ) {
+        return "'" & arguments.str & "'";
+    }
+
+    /**
+     * Unescapes a string for SQL by removing the surrounding single quotes.
+     *
+     * @str      The string to unescape for SQL.
+     *
+     * @returns  The string unescaped for SQL.
+     */
+    private string function unescapeSQL( required string str ) {
+        return mid( arguments.str, 2, len( arguments.str ) - 2 );
+    }
+
+}

--- a/models/SQLCommenter/SQLCommenter.cfc
+++ b/models/SQLCommenter/SQLCommenter.cfc
@@ -65,7 +65,7 @@ component singleton {
      *
      * @return         A struct of key/value pairs from the comment.
      */
-    private struct function parseCommentString( required string commentString ) {
+    public struct function parseCommentString( required string commentString ) {
         arguments.commentString = trim( arguments.commentString );
         arguments.commentString = replace( arguments.commentString, "/*", "" );
         arguments.commentString = replace( arguments.commentString, "*/", "" );

--- a/models/SQLCommenter/SQLCommenter.cfc
+++ b/models/SQLCommenter/SQLCommenter.cfc
@@ -61,7 +61,7 @@ component singleton {
     /**
      * Parses a comment string into a struct.
      *
-     * @commentString  The comment string to parse into a struct
+     * @commentString  The comment string to parse into a struct.
      *
      * @return         A struct of key/value pairs from the comment.
      */

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -90,6 +90,12 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
+    public Column function guid( required string name ) {
+        arguments.type = "GUID";
+        arguments.length = 36;
+        return appendColumn( argumentCollection = arguments );
+    }
+
     public Column function increments( required string name, string indexName ) {
         arguments.autoIncrement = true;
         param arguments.indexName = "pk_#getTable()#_#name#";
@@ -317,7 +323,7 @@ component accessors="true" {
 
     public Column function uuid( required string name ) {
         arguments.type = "UUID";
-        arguments.length = 36;
+        arguments.length = 35;
         return appendColumn( argumentCollection = arguments );
     }
 

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -447,6 +447,15 @@ component accessors="true" {
         return this;
     }
 
+    public Blueprint function dropIndex( required any name ) {
+        if ( !isSimpleValue( arguments.name ) ) {
+            dropIndex( arguments.name.getName() );
+        } else {
+            addCommand( "dropIndex", { name: arguments.name } );
+        }
+        return this;
+    }
+
     public Blueprint function dropForeignKey( required any name ) {
         if ( !isSimpleValue( arguments.name ) ) {
             dropForeignKey( arguments.name.getName() );

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
         }
     },
     "app":{
-        "cfengine":"adobe@2016"
+        "cfengine":"adobe@2018"
     },
     "directoryBrowsing":"true",
     "JVM":{

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -1,6 +1,7 @@
 component {
 
     this.enableNullSupport = shouldEnableFullNullSupport();
+    this.timezone = "UTC";
 
     this.mappings[ "/tests" ] = getDirectoryFromPath( getCurrentTemplatePath() );
     this.mappings[ "/qb" ] = expandPath( "/" );

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -2264,18 +2264,14 @@ component extends="testbox.system.BaseSpec" {
 
                 it( "turns a function into a subselect", function() {
                     testCase( function( builder ) {
+                        var subselect = function( qb ) {
+                            qb.from( "departments" )
+                                .select( "name" )
+                                .whereColumn( "employees.departmentId", "departments.id" );
+                        };
                         return builder
                             .table( "employees" )
-                            .update(
-                                values = {
-                                    "departmentName": function( qb ) {
-                                        qb.from( "departments" )
-                                            .select( "name" )
-                                            .whereColumn( "employees.departmentId", "departments.id" );
-                                    }
-                                },
-                                toSql = true
-                            );
+                            .update( values = { "departmentName": subselect }, toSql = true );
                     }, updateWithSubselect() );
                 } );
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -111,6 +111,18 @@ component extends="testbox.system.BaseSpec" {
                         }, selectRawArray() );
                     } );
 
+                    it( "provides a grammar-specific helper for concat", function() {
+                        testCase( function( builder ) {
+                            builder.select( builder.concat( "my_alias", "a,b,c,d" ) ).from( "users" );
+                        }, selectConcat() );
+                    } );
+
+                    it( "concat can accept an array of values", function() {
+                        testCase( function( builder ) {
+                            builder.select( builder.concat( "my_alias", [ "a", "b", "c", "d" ] ) ).from( "users" );
+                        }, selectConcatArray() );
+                    } );
+
                     it( "can clear the selected columns for a query", function() {
                         testCase( function( builder ) {
                             builder

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1818,6 +1818,23 @@ component extends="testbox.system.BaseSpec" {
                             ;
                         }, unionAll() );
                     } );
+
+                    it( "can run an aggregate query like count on a union query", function() {
+                        testCase( function( builder ) {
+                            return builder
+                                .select( "name" )
+                                .from( "users" )
+                                .where( "id", 1 )
+                                .union( function( q ) {
+                                    q.select( "name" )
+                                        .from( "users" )
+                                        .where( "id", 2 )
+                                    ;
+                                } )
+                                .count( toSQL = true )
+                            ;
+                        }, unionCount() );
+                    } );
                 } );
 
                 describe( "common table expressions (i.e. CTEs)", function() {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -119,7 +119,15 @@ component extends="testbox.system.BaseSpec" {
 
                     it( "concat can accept an array of values", function() {
                         testCase( function( builder ) {
-                            builder.select( builder.concat( "my_alias", [ "a", "b", "c", "d" ] ) ).from( "users" );
+                            // I kid you not, ACF2018 wouldn't let me pass `[ "a", "b", "c", "d" ]`
+                            var items = [];
+                            items
+                                .append( "a" )
+                                .append( "b" )
+                                .append( "c" )
+                                .append( "d" );
+
+                            builder.select( builder.concat( "my_alias", items ) ).from( "users" );
                         }, selectConcatArray() );
                     } );
 
@@ -1797,16 +1805,13 @@ component extends="testbox.system.BaseSpec" {
                                 .unionAll( function( q ) {
                                     q.select( "name" )
                                         .from( "users" )
-                                        .where( "id", 2 )
-                                    ;
+                                        .where( "id", 2 );
                                 } )
                                 .unionAll( function( q ) {
                                     q.select( "name" )
                                         .from( "users" )
-                                        .where( "id", 3 )
-                                    ;
-                                } )
-                            ;
+                                        .where( "id", 3 );
+                                } );
                         }, unionAll() );
                     } );
 
@@ -1840,11 +1845,9 @@ component extends="testbox.system.BaseSpec" {
                                 .union( function( q ) {
                                     q.select( "name" )
                                         .from( "users" )
-                                        .where( "id", 2 )
-                                    ;
+                                        .where( "id", 2 );
                                 } )
-                                .count( toSQL = true )
-                            ;
+                                .count( toSQL = true );
                         }, unionCount() );
                     } );
                 } );

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1977,6 +1977,25 @@ component extends="testbox.system.BaseSpec" {
                             ;
                         }, commonTableExpressionBindingOrder() );
                     } );
+
+                    it( "can insert based off of a cte", function() {
+                        testCase( function( builder ) {
+                            return builder
+                                .with( "UsersCTE", function( q ) {
+                                    q.select( "*" )
+                                        .from( "users" )
+                                        .where( "users.age", ">", 25 )
+                                    ;
+                                } )
+                                .table( "oldUsers" )
+                                .insertUsing(
+                                    source = function( qb ) {
+                                        qb.from( "UsersCTE" ).select( [ "fname", "lname", "username", "age" ] );
+                                    },
+                                    toSQL = true
+                                );
+                        }, cteInsertUsing() );
+                    } );
                 } );
 
                 describe( "limits", function() {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -2038,7 +2038,12 @@ component extends="testbox.system.BaseSpec" {
 
                     it( "returns zeros values less than zero", function() {
                         testCase( function( builder ) {
-                            builder.from( "users" ).forPage( 0, -2 );
+                            builder
+                                .setShouldMaxRowsOverrideToAll( function() {
+                                    return false;
+                                } )
+                                .from( "users" )
+                                .forPage( 0, -2 );
                         }, forPageWithLessThanZeroValues() );
                     } );
                 } );

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -1766,8 +1766,7 @@ component extends="testbox.system.BaseSpec" {
             for ( var i = 1; i <= expected.len(); i++ ) {
                 expect( statements[ i ] ).toBeWithCase( expected[ i ] );
             }
-        }
-        catch ( any e ) {
+        } catch ( any e ) {
             if ( !isSimpleValue( expected ) && !isArray( expected ) && structKeyExists( expected, "exception" ) ) {
                 expect( e.type ).toBe( expected.exception );
                 return;

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -1752,18 +1752,27 @@ component extends="testbox.system.BaseSpec" {
     }
 
     private function testCase( callback, expected ) {
-        var schema = getBuilder();
-        var statements = callback( schema );
-        if ( !isSimpleValue( statements ) ) {
-            statements = statements.toSql();
+        try {
+            var schema = getBuilder();
+            var statements = callback( schema );
+            if ( !isSimpleValue( statements ) ) {
+                statements = statements.toSql();
+            }
+            if ( !isArray( statements ) ) {
+                statements = [ statements ];
+            }
+            expect( statements ).toBeArray();
+            expect( statements ).toHaveLength( arrayLen( expected ) );
+            for ( var i = 1; i <= expected.len(); i++ ) {
+                expect( statements[ i ] ).toBeWithCase( expected[ i ] );
+            }
         }
-        if ( !isArray( statements ) ) {
-            statements = [ statements ];
-        }
-        expect( statements ).toBeArray();
-        expect( statements ).toHaveLength( arrayLen( expected ) );
-        for ( var i = 1; i <= expected.len(); i++ ) {
-            expect( statements[ i ] ).toBeWithCase( expected[ i ] );
+        catch ( any e ) {
+            if ( !isSimpleValue( expected ) && !isArray( expected ) && structKeyExists( expected, "exception" ) ) {
+                expect( e.type ).toBe( expected.exception );
+                return;
+            }
+            rethrow;
         }
     }
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -1271,6 +1271,32 @@ component extends="testbox.system.BaseSpec" {
                                 );
                             }, dropForeignKey() );
                         } );
+
+                        it( "drop index", function() {
+                            testCase( function( schema ) {
+                                return schema.alter(
+                                    "users",
+                                    function( table ) {
+                                        table.dropIndex( "idx_username" );
+                                    },
+                                    {},
+                                    false
+                                );
+                            }, dropIndexFromName() );
+                        } );
+
+                        it( "drop index (from index object)", function() {
+                            testCase( function( schema ) {
+                                return schema.alter(
+                                    "users",
+                                    function( table ) {
+                                        table.dropIndex( table.index( "username" ) );
+                                    },
+                                    {},
+                                    false
+                                );
+                            }, dropIndexFromIndex() );
+                        } );
                     } );
                 } );
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -341,6 +341,19 @@ component extends="testbox.system.BaseSpec" {
                     }, floatWithLengthAndPrecision() );
                 } );
 
+                it( "guid", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "users",
+                            function( table ) {
+                                table.guid( "id" );
+                            },
+                            {},
+                            false
+                        );
+                    }, this.guid() );
+                } );
+
                 it( "increments", function() {
                     testCase( function( schema ) {
                         return schema.create(
@@ -1094,7 +1107,7 @@ component extends="testbox.system.BaseSpec" {
                         return schema.create(
                             "users",
                             function( table ) {
-                                table.uuid( "id" ).nullable();
+                                table.guid( "id" ).nullable();
                             },
                             {},
                             false

--- a/tests/specs/Query/Abstract/BuilderGetSpec.cfc
+++ b/tests/specs/Query/Abstract/BuilderGetSpec.cfc
@@ -36,11 +36,7 @@ component extends="testbox.system.BaseSpec" {
                 expect( binding.cfsqltype ).toBe( "cf_sql_varchar" );
                 var binding = bindings[ 2 ];
                 expect( binding.value ).toBe( 10 );
-                if ( isACF2016() ) {
-                    expect( binding.cfsqltype ).toBe( "cf_sql_varchar" );
-                } else {
-                    expect( binding.cfsqltype ).toBe( "cf_sql_numeric" );
-                }
+                expect( binding.cfsqltype ).toBe( "CF_SQL_INTEGER" );
             } );
 
             it( "retreives a map of bindings", function() {
@@ -54,12 +50,6 @@ component extends="testbox.system.BaseSpec" {
                 expect( bindings ).toBeStruct();
             } );
         } );
-    }
-
-    private boolean function isACF2016() {
-        return server.keyExists( "coldfusion" ) &&
-        !server.keyExists( "lucee" ) &&
-        left( server.coldfusion.productversion, 4 ) == "2016";
     }
 
 }

--- a/tests/specs/Query/Abstract/PaginationSpec.cfc
+++ b/tests/specs/Query/Abstract/PaginationSpec.cfc
@@ -10,7 +10,10 @@ component extends="testbox.system.BaseSpec" {
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
                 builder.$( "count", 45 );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).paginate();
 
@@ -33,7 +36,10 @@ component extends="testbox.system.BaseSpec" {
                     expectedResults.append( { "id": i } );
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var nestedBuilder = getBuilder();
                 nestedBuilder.$( "count", 15 );
@@ -64,7 +70,10 @@ component extends="testbox.system.BaseSpec" {
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
                 builder.$( "count", 45 );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).paginate( page = 2 );
 
@@ -88,7 +97,10 @@ component extends="testbox.system.BaseSpec" {
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
                 builder.$( "count", 45 );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).paginate( page = 1, maxRows = 10 );
 
@@ -122,7 +134,10 @@ component extends="testbox.system.BaseSpec" {
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
                 builder.$( "count", 45 );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).paginate();
 
@@ -143,7 +158,10 @@ component extends="testbox.system.BaseSpec" {
                     expectedResults.append( { "id": i } );
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).simplePaginate();
 
@@ -165,7 +183,10 @@ component extends="testbox.system.BaseSpec" {
                     expectedResults.append( { "id": i } );
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).simplePaginate( page = 2 );
 
@@ -187,7 +208,10 @@ component extends="testbox.system.BaseSpec" {
                     expectedResults.append( { "id": i } );
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).simplePaginate( page = 1, maxRows = 10 );
 
@@ -227,7 +251,10 @@ component extends="testbox.system.BaseSpec" {
                     expectedResults.append( { "id": i } );
                 }
                 var expectedQuery = queryNew( "id", "integer", expectedResults );
-                builder.$( "runQuery", expectedQuery );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
 
                 var results = builder.from( "users" ).simplePaginate();
 
@@ -253,6 +280,10 @@ component extends="testbox.system.BaseSpec" {
             .map( function( binding ) {
                 return binding.value;
             } );
+    }
+
+    private boolean function supportsNativeReturnType() {
+        return server.keyExists( "lucee" ) || listFirst( server.coldfusion.productversion ) >= 2021;
     }
 
 }

--- a/tests/specs/Query/Abstract/PaginationSpec.cfc
+++ b/tests/specs/Query/Abstract/PaginationSpec.cfc
@@ -116,6 +116,35 @@ component extends="testbox.system.BaseSpec" {
                 } );
             } );
 
+            it( "can does not limit the query when the maxrows passes the override check", function() {
+                var builder = getBuilder();
+                builder.setShouldMaxRowsOverrideToAll( function( maxrows ) {
+                    return maxrows <= 0;
+                } );
+
+                var expectedResults = [];
+                for ( var i = 1; i <= 45; i++ ) {
+                    expectedResults.append( { "id": i } );
+                }
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 45 );
+                builder.$(
+                    "runQuery",
+                    supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                );
+
+                var results = builder.from( "users" ).paginate( page = 1, maxRows = 0 );
+
+                expect( results.pagination ).toBe( {
+                    "maxRows": 0,
+                    "offset": 0,
+                    "page": 1,
+                    "totalPages": 0,
+                    "totalRecords": 45
+                } );
+                expect( results.results ).toBe( expectedResults );
+            } );
+
             it( "can provide a custom paginator shell", function() {
                 var builder = getBuilder();
                 builder.setPaginationCollector( {

--- a/tests/specs/Query/Abstract/QueryDebuggingSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryDebuggingSpec.cfc
@@ -21,15 +21,22 @@ component extends="testbox.system.BaseSpec" {
                 var query = getBuilder()
                     .from( "users" )
                     .join( "logins", function( j ) {
-                        j.on( "users.id", "logins.user_id" ).where( "logins.created_date", ">", "01 Jun 2019" );
+                        j.on( "users.id", "logins.user_id" )
+                            .where( "logins.created_date", ">", parseDateTime( "01 Jun 2019" ) );
                     } )
                     .whereIn( "users.type", [ "admin", "manager" ] )
                     .whereNotNull( "active" )
                     .orderBy( "logins.created_date", "desc" );
 
-                expect( query.toSQL( showBindings = true ) ).toBe(
-                    "SELECT * FROM ""users"" INNER JOIN ""logins"" ON ""users"".""id"" = ""logins"".""user_id"" AND ""logins"".""created_date"" > {""value"":""01 Jun 2019"",""cfsqltype"":""CF_SQL_TIMESTAMP"",""null"":false} WHERE ""users"".""type"" IN ({""value"":""admin"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}, {""value"":""manager"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}) AND ""active"" IS NOT NULL ORDER BY ""logins"".""created_date"" DESC"
-                );
+                if ( isLucee() ) {
+                    expect( query.toSQL( showBindings = true ) ).toBe(
+                        "SELECT * FROM ""users"" INNER JOIN ""logins"" ON ""users"".""id"" = ""logins"".""user_id"" AND ""logins"".""created_date"" > {""value"":""June, 01 2019 00:00:00 +0000"",""cfsqltype"":""CF_SQL_TIMESTAMP"",""null"":false} WHERE ""users"".""type"" IN ({""value"":""admin"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}, {""value"":""manager"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}) AND ""active"" IS NOT NULL ORDER BY ""logins"".""created_date"" DESC"
+                    );
+                } else {
+                    expect( query.toSQL( showBindings = true ) ).toBe(
+                        "SELECT * FROM ""users"" INNER JOIN ""logins"" ON ""users"".""id"" = ""logins"".""user_id"" AND ""logins"".""created_date"" > {""value"":""June, 01 2019 00:00:00"",""cfsqltype"":""CF_SQL_TIMESTAMP"",""null"":false} WHERE ""users"".""type"" IN ({""value"":""admin"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}, {""value"":""manager"",""cfsqltype"":""CF_SQL_VARCHAR"",""null"":false}) AND ""active"" IS NOT NULL ORDER BY ""logins"".""created_date"" DESC"
+                    );
+                }
             } );
 
             it( "provides a useful error message when calling `from` with a closure", function() {
@@ -46,6 +53,10 @@ component extends="testbox.system.BaseSpec" {
         var grammar = getMockBox().createMock( "qb.models.Grammars.BaseGrammar" ).init();
         var builder = getMockBox().createMock( "qb.models.Query.QueryBuilder" ).init( grammar );
         return builder;
+    }
+
+    private boolean function isLucee() {
+        return server.keyExists( "lucee" );
     }
 
 }

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -89,7 +89,9 @@ component extends="testbox.system.BaseSpec" {
                     builder
                         .$( "runQuery" )
                         .$args( sql = "SELECT * FROM ""users"" WHERE ""name"" = ? LIMIT 1", options = {} )
-                        .$results( expectedQuery );
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                        );
 
                     var results = builder
                         .from( "users" )
@@ -118,7 +120,9 @@ component extends="testbox.system.BaseSpec" {
                     builder
                         .$( "runQuery" )
                         .$args( sql = "SELECT * FROM ""users""", options = {} )
-                        .$results( expectedQuery );
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                        );
 
                     var results = builder.from( "users" ).last();
 
@@ -135,7 +139,9 @@ component extends="testbox.system.BaseSpec" {
                     builder
                         .$( "runQuery" )
                         .$args( sql = "SELECT * FROM ""users"" WHERE ""id"" = ? LIMIT 1", options = {} )
-                        .$results( expectedQuery );
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                        );
 
                     var results = builder.from( "users" ).find( 1 );
 
@@ -482,13 +488,19 @@ component extends="testbox.system.BaseSpec" {
                         .$results( queryNew( "aggregate", "varchar", [ { "aggregate": 257 } ] ) )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 0", options = {} )
-                        .$results( expectedQuery100 )
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery100 ) : expectedQuery100
+                        )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 100", options = {} )
-                        .$results( expectedQuery100 )
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery100 ) : expectedQuery100
+                        )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 200", options = {} )
-                        .$results( expectedQueryRest );
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQueryRest ) : expectedQueryRest
+                        );
 
                     builder
                         .select( "name" )
@@ -519,13 +531,19 @@ component extends="testbox.system.BaseSpec" {
                         .$results( queryNew( "aggregate", "varchar", [ { "aggregate": 257 } ] ) )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 0", options = {} )
-                        .$results( expectedQuery100 )
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery100 ) : expectedQuery100
+                        )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 100", options = {} )
-                        .$results( expectedQuery100 )
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery100 ) : expectedQuery100
+                        )
                         .$( "runQuery" )
                         .$args( sql = "SELECT ""name"" FROM ""users"" LIMIT 100 OFFSET 200", options = {} )
-                        .$results( expectedQueryRest );
+                        .$results(
+                            supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQueryRest ) : expectedQueryRest
+                        );
 
                     builder
                         .select( "name" )
@@ -844,14 +862,16 @@ component extends="testbox.system.BaseSpec" {
         } );
 
         describe( "returnFormat", function() {
-            it( "has a default return value of array", function() {
+            it( "has a default return format of array", function() {
                 var builder = getBuilder();
                 var data = [ { id: 1 } ];
                 var expectedQuery = queryNew( "id", "integer", data );
                 builder
                     .$( "runQuery" )
                     .$args( sql = "SELECT ""id"" FROM ""users""", options = {} )
-                    .$results( expectedQuery );
+                    .$results(
+                        supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                    );
 
                 var results = builder
                     .select( "id" )
@@ -873,7 +893,9 @@ component extends="testbox.system.BaseSpec" {
                 builder
                     .$( "runQuery" )
                     .$args( sql = "SELECT ""id"" FROM ""users""", options = {} )
-                    .$results( expectedQuery );
+                    .$results(
+                        supportsNativeReturnType() ? builder.getUtils().queryToArrayOfStructs( expectedQuery ) : expectedQuery
+                    );
 
                 var results = builder
                     .select( "id" )
@@ -962,6 +984,10 @@ component extends="testbox.system.BaseSpec" {
             .map( function( binding ) {
                 return binding.value;
             } );
+    }
+
+    private boolean function supportsNativeReturnType() {
+        return server.keyExists( "lucee" ) || listFirst( server.coldfusion.productversion ) >= 2021;
     }
 
 }

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -691,6 +691,28 @@ component extends="testbox.system.BaseSpec" {
                     expect( runQueryLog ).toHaveLength( 1, "runQuery should have been called once" );
                     expect( runQueryLog[ 1 ] ).toBe( { sql: "SELECT COALESCE(COUNT(DISTINCT ""name""), 0) AS ""aggregate"" FROM ""users""", options: {} } );
                 } );
+
+                it( "correctly ignores distinct when doing an open count", function() {
+                    var builder = getBuilder();
+                    var expectedCount = 1;
+                    var expectedQuery = queryNew( "aggregate", "integer", [ { aggregate: expectedCount } ] );
+                    builder
+                        .$( "runQuery" )
+                        .$args( sql = "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM ""users""", options = {} )
+                        .$results( expectedQuery );
+
+                    var results = builder
+                        .from( "users" )
+                        .distinct()
+                        .count();
+
+                    expect( results ).toBe( expectedCount );
+
+                    var runQueryLog = builder.$callLog().runQuery;
+                    expect( runQueryLog ).toBeArray();
+                    expect( runQueryLog ).toHaveLength( 1, "runQuery should have been called once" );
+                    expect( runQueryLog[ 1 ] ).toBe( { sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM ""users""", options: {} } );
+                } );
             } );
 
             describe( "max", function() {

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -854,6 +854,33 @@ component extends="testbox.system.BaseSpec" {
 
                     expect( builder.getAggregate() ).toBeEmpty( "Aggregate should have been cleared after running" );
                 } );
+
+                it( "can use the sumRaw shortcut method", function() {
+                    var builder = getBuilder();
+                    var expectedSum = 424242;
+                    var expectedQuery = queryNew( "aggregate", "integer", [ { aggregate: expectedSum } ] );
+                    builder
+                        .$( "runQuery" )
+                        .$args(
+                            sql = "SELECT COALESCE(SUM(netAdditions + netTransfers), 0) AS ""aggregate"" FROM ""accounts""",
+                            options = {}
+                        )
+                        .$results( expectedQuery );
+
+                    var results = builder.from( "accounts" ).sumRaw( "netAdditions + netTransfers" );
+
+                    expect( results ).toBe( expectedSum );
+
+                    var runQueryLog = builder.$callLog().runQuery;
+                    expect( runQueryLog ).toBeArray();
+                    expect( runQueryLog ).toHaveLength( 1, "runQuery should have been called once" );
+                    expect( runQueryLog[ 1 ] ).toBe( {
+                        sql: "SELECT COALESCE(SUM(netAdditions + netTransfers), 0) AS ""aggregate"" FROM ""accounts""",
+                        options: {}
+                    } );
+
+                    expect( builder.getAggregate() ).toBeEmpty( "Aggregate should have been cleared after running" );
+                } );
             } );
 
             describe( "exists", function() {

--- a/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
@@ -17,35 +17,22 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
 
             describe( "numbers", function() {
                 it( "integers", function() {
-                    if ( isACF2016() ) {
-                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_VARCHAR" );
-                    } else {
-                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
-                        variables.utils.setAutoDeriveNumericType( true );
-                        expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_INTEGER" );
-                        variables.utils.setAutoDeriveNumericType( false );
-                    }
+                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
+                    variables.utils.setAutoDeriveNumericType( true );
+                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_INTEGER" );
+                    variables.utils.setAutoDeriveNumericType( false );
                 } );
 
                 it( "decimals", function() {
-                    if ( isACF2016() ) {
-                        variables.utils.setStrictDateDetection( true );
-                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_VARCHAR" );
-                        variables.utils.setStrictDateDetection( false );
-                    } else {
-                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_NUMERIC" );
-                        variables.utils.setAutoDeriveNumericType( true );
-                        expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_DECIMAL" );
-                        variables.utils.setAutoDeriveNumericType( false );
-                    }
+                    expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_NUMERIC" );
+                    variables.utils.setAutoDeriveNumericType( true );
+                    expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_DECIMAL" );
+                    variables.utils.setAutoDeriveNumericType( false );
                 } );
             } );
 
             it( "dates", function() {
                 expect( utils.inferSqlType( now() ) ).toBe( "CF_SQL_TIMESTAMP" );
-                if ( isLucee() ) {
-                    expect( utils.inferSqlType( "06 12345" ) ).toBe( "CF_SQL_TIMESTAMP" );
-                }
                 variables.utils.setStrictDateDetection( true );
                 expect( utils.inferSqlType( now() ) ).toBe( "CF_SQL_TIMESTAMP" );
                 expect( utils.inferSqlType( "06 12345" ) ).toBe( "CF_SQL_VARCHAR" );
@@ -71,11 +58,7 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
 
             describe( "it infers the sql type from the members of an array", function() {
                 it( "if all the members of the array are the same", function() {
-                    if ( isACF2016() ) {
-                        expect( utils.inferSqlType( [ 1, 2 ] ) ).toBe( "CF_SQL_VARCHAR" );
-                    } else {
-                        expect( utils.inferSqlType( [ 1, 2 ] ) ).toBe( "CF_SQL_NUMERIC" );
-                    }
+                    expect( utils.inferSqlType( [ 1, 2 ] ) ).toBe( "CF_SQL_NUMERIC" );
                 } );
 
                 it( "but defaults to CF_SQL_VARCHAR if they are different", function() {
@@ -93,7 +76,7 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
 
         describe( "extractBinding()", function() {
             it( "includes sensible defaults", function() {
-                var binding = utils.extractBinding( "05/10/2016" );
+                var binding = utils.extractBinding( parseDateTime( "05/10/2016" ) );
 
                 expect( binding ).toBeStruct();
                 expect( binding.value ).toBe( "05/10/2016" );
@@ -230,15 +213,6 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
                 expect( queryOne.getFrom() ).toBe( "foo" );
             } );
         } );
-    }
-
-    private boolean function isACF2016() {
-        return server.keyExists( "coldfusion" ) &&
-        !server.keyExists( "lucee" ) &&
-        left( server.coldfusion.productversion, 4 ) == "2016";
-    }
-    private boolean function isLucee() {
-        return server.keyExists( "lucee" );
     }
 
 }

--- a/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
@@ -17,17 +17,17 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
 
             describe( "numbers", function() {
                 it( "integers", function() {
-                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
-                    variables.utils.setAutoDeriveNumericType( true );
                     expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_INTEGER" );
                     variables.utils.setAutoDeriveNumericType( false );
+                    expect( utils.inferSqlType( 100 ) ).toBe( "CF_SQL_NUMERIC" );
+                    variables.utils.setAutoDeriveNumericType( true );
                 } );
 
                 it( "decimals", function() {
-                    expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_NUMERIC" );
-                    variables.utils.setAutoDeriveNumericType( true );
                     expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_DECIMAL" );
                     variables.utils.setAutoDeriveNumericType( false );
+                    expect( utils.inferSqlType( 4.50 ) ).toBe( "CF_SQL_NUMERIC" );
+                    variables.utils.setAutoDeriveNumericType( true );
                 } );
             } );
 
@@ -58,7 +58,7 @@ component displayname="QueryUtilsSpec" extends="testbox.system.BaseSpec" {
 
             describe( "it infers the sql type from the members of an array", function() {
                 it( "if all the members of the array are the same", function() {
-                    expect( utils.inferSqlType( [ 1, 2 ] ) ).toBe( "CF_SQL_NUMERIC" );
+                    expect( utils.inferSqlType( [ 1, 2 ] ) ).toBe( "CF_SQL_INTEGER" );
                 } );
 
                 it( "but defaults to CF_SQL_VARCHAR if they are different", function() {

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -59,6 +59,14 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT substr( foo, 6 ), trim( bar ) FROM `users`";
     }
 
+    function selectConcat() {
+        return "SELECT CONCAT(a,b,c,d) AS `my_alias` FROM `users`";
+    }
+
+    function selectConcatArray() {
+        return "SELECT CONCAT(a,b,c,d) AS `my_alias` FROM `users`";
+    }
+
     function clearSelect() {
         return "SELECT * FROM `users`";
     }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -564,6 +564,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function unionCount() {
+        return {
+            sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM (SELECT `name` FROM `users` WHERE `id` = ? UNION SELECT `name` FROM `users` WHERE `id` = ?) AS `qb_aggregate_source`",
+            bindings: [ 1, 2 ]
+        };
+    }
+
     function commonTableExpression() {
         return {
             sql: "WITH `UsersCTE` AS (SELECT * FROM `users` INNER JOIN `contacts` ON `users`.`id` = `contacts`.`id` WHERE `users`.`age` > ?) SELECT * FROM `UsersCTE` WHERE `user`.`id` NOT IN (?, ?)",

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -614,6 +614,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function cteInsertUsing() {
+        return {
+            sql: "INSERT INTO `oldUsers` (`fname`, `lname`, `username`, `age`) WITH `UsersCTE` AS (SELECT * FROM `users` WHERE `users`.`age` > ?) SELECT `fname`, `lname`, `username`, `age` FROM `UsersCTE`",
+            bindings: [ 25 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM `users` LIMIT 3";
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -577,6 +577,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function unionCount() {
+        return {
+            sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM (SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ? UNION SELECT ""NAME"" FROM ""USERS"" WHERE ""ID"" = ?) ""QB_AGGREGATE_SOURCE""",
+            bindings: [ 1, 2 ]
+        };
+    }
+
     function commonTableExpression() {
         return {
             sql: "WITH ""USERSCTE"" AS (SELECT * FROM ""USERS"" INNER JOIN ""CONTACTS"" ON ""USERS"".""ID"" = ""CONTACTS"".""ID"" WHERE ""USERS"".""AGE"" > ?) SELECT * FROM ""USERSCTE"" WHERE ""USER"".""ID"" NOT IN (?, ?)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -59,6 +59,14 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT substr( foo, 6 ), trim( bar ) FROM ""USERS""";
     }
 
+    function selectConcat() {
+        return "SELECT CONCAT(a,b,c,d) AS ""MY_ALIAS"" FROM ""USERS""";
+    }
+
+    function selectConcatArray() {
+        return "SELECT CONCAT(a,b,c,d) AS ""MY_ALIAS"" FROM ""USERS""";
+    }
+
     function clearSelect() {
         return "SELECT * FROM ""USERS""";
     }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -627,6 +627,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function cteInsertUsing() {
+        return {
+            sql: "WITH ""USERSCTE"" AS (SELECT * FROM ""USERS"" WHERE ""USERS"".""AGE"" > ?) INSERT INTO ""OLDUSERS"" (""FNAME"", ""LNAME"", ""USERNAME"", ""AGE"") SELECT ""FNAME"", ""LNAME"", ""USERNAME"", ""AGE"" FROM ""USERSCTE""",
+            bindings: [ 25 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM (SELECT results.*, ROWNUM AS ""QB_RN"" FROM (SELECT * FROM ""USERS"") results ) WHERE ""QB_RN"" <= 3";
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -59,6 +59,14 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT substr( foo, 6 ), trim( bar ) FROM ""users""";
     }
 
+    function selectConcat() {
+        return "SELECT CONCAT(a,b,c,d) AS ""my_alias"" FROM ""users""";
+    }
+
+    function selectConcatArray() {
+        return "SELECT CONCAT(a,b,c,d) AS ""my_alias"" FROM ""users""";
+    }
+
     function clearSelect() {
         return "SELECT * FROM ""users""";
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -571,6 +571,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function unionCount() {
+        return {
+            sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM (SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ?) AS ""qb_aggregate_source""",
+            bindings: [ 1, 2 ]
+        };
+    }
+
     function commonTableExpression() {
         return {
             sql: "WITH ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -621,6 +621,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function cteInsertUsing() {
+        return {
+            sql: "WITH ""UsersCTE"" AS (SELECT * FROM ""users"" WHERE ""users"".""age"" > ?) INSERT INTO ""oldUsers"" (""fname"", ""lname"", ""username"", ""age"") SELECT ""fname"", ""lname"", ""username"", ""age"" FROM ""UsersCTE""",
+            bindings: [ 25 ]
+        };
+    }
+
     function limit() {
         return "SELECT * FROM ""users"" LIMIT 3";
     }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -778,7 +778,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsert() {
         return {
-            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
             bindings: [
                 1,
                 "2021-09-08 12:00:00",
@@ -790,7 +790,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsertAllValues() {
         return {
-            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE ""active"" = EXCLUDED.""active"", ""createdDate"" = EXCLUDED.""createdDate"", ""modifiedDate"" = EXCLUDED.""modifiedDate"", ""username"" = EXCLUDED.""username""",
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""createdDate"" = EXCLUDED.""createdDate"", ""modifiedDate"" = EXCLUDED.""modifiedDate"", ""username"" = EXCLUDED.""username""",
             bindings: [
                 1,
                 "2021-09-08 12:00:00",
@@ -814,7 +814,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsertWithInsertedValue() {
         return {
-            sql: "INSERT INTO ""stats"" (""postId"", ""viewedDate"", ""views"") VALUES (?, ?, ?), (?, ?, ?) ON CONFLICT (""postId"", ""viewedDate"") DO UPDATE ""views"" = stats.views + 1",
+            sql: "INSERT INTO ""stats"" (""postId"", ""viewedDate"", ""views"") VALUES (?, ?, ?), (?, ?, ?) ON CONFLICT (""postId"", ""viewedDate"") DO UPDATE SET ""views"" = stats.views + 1",
             bindings: [
                 1,
                 "2021-09-08",
@@ -828,7 +828,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsertSingleTarget() {
         return {
-            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
             bindings: [
                 1,
                 "2021-09-08 12:00:00",
@@ -840,14 +840,14 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsertFromClosure() {
         return {
-            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
             bindings: [ 1 ]
         };
     }
 
     function upsertFromBuilder() {
         return {
-            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
             bindings: [ 1 ]
         };
     }

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -702,6 +702,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function cteInsertUsing() {
+        return {
+            sql: "WITH ""UsersCTE"" AS (SELECT * FROM ""users"" WHERE ""users"".""age"" > ?) INSERT INTO ""oldUsers"" (""fname"", ""lname"", ""username"", ""age"") SELECT ""fname"", ""lname"", ""username"", ""age"" FROM ""UsersCTE""",
+            bindings: [ 25 ]
+        };
+    }
+
     function commonTableExpressionBindingOrder() {
         return {
             sql: "WITH RECURSIVE ""OrderCTE"" AS (SELECT * FROM ""orders"" WHERE ""created"" > ?), ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1,6 +1,5 @@
 component extends="tests.resources.AbstractQueryBuilderSpec" {
 
-
     private function getBuilder() {
         variables.utils = getMockBox().createMock( "qb.models.Query.QueryUtils" ).init();
         variables.grammar = getMockBox().createMock( "qb.models.Grammars.SQLiteGrammar" ).init( variables.utils );
@@ -15,7 +14,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     function selectSpecificColumn() {
         return "SELECT ""name"" FROM ""users""";
     }
-    
+
     function selectMultipleArray() {
         return "SELECT ""name"", COUNT(*) FROM ""users""";
     }
@@ -74,7 +73,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     function selectConcatArray() {
         return "SELECT a || b || c || d AS ""my_alias"" FROM ""users""";
     }
-    
+
     function clearSelect() {
         return "SELECT * FROM ""users""";
     }
@@ -111,33 +110,36 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function fromDerivedTable() {
-        return { sql: "SELECT * FROM (SELECT ""id"", ""name"" FROM ""users"" WHERE ""age"" >= ?) AS ""u""", bindings: [ 21 ] };
+        return {
+            sql: "SELECT * FROM (SELECT ""id"", ""name"" FROM ""users"" WHERE ""age"" >= ?) AS ""u""",
+            bindings: [ 21 ]
+        };
     }
 
     function noLock() {
         return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
     }
-    
+
     function sharedLock() {
         return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
     }
-    
+
     function lockForUpdate() {
         return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
     }
-    
+
     function lockForUpdateSkipLocked() {
         return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
     }
-    
+
     function lockArbitraryString() {
         return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
     }
-    
+
     function table() {
         return "SELECT * FROM ""users""";
     }
-    
+
     function tablePrefix() {
         return "SELECT * FROM ""prefix_users""";
     }
@@ -317,7 +319,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function orWhereIn() {
-        return { sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)", bindings: [ "foo", 1, 2, 3 ] };
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)",
+            bindings: [ "foo", 1, 2, 3 ]
+        };
     }
 
     function whereInRaw() {
@@ -371,7 +376,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function joinWithWhere() {
-        return { sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""contacts"".""balance"" < ?", bindings: [ 100 ] };
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""contacts"".""balance"" < ?",
+            bindings: [ 100 ]
+        };
     }
 
     function leftJoin() {
@@ -415,8 +423,8 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
             sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""users"".""name"" = ""contacts"".""name"" OR ""users"".""admin"" = ?",
             bindings: [ 1 ]
         };
-    }    
-    
+    }
+
     function joinWithWhereNull() {
         return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" AND ""contacts"".""deleted_date"" IS NULL";
     }
@@ -812,7 +820,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function updateWithWhere() {
-        return { sql: "UPDATE ""users"" SET ""email"" = ?, ""name"" = ? WHERE ""Id"" = ?", bindings: [ "foo", "bar", 1 ] };
+        return {
+            sql: "UPDATE ""users"" SET ""email"" = ?, ""name"" = ? WHERE ""Id"" = ?",
+            bindings: [ "foo", "bar", 1 ]
+        };
     }
 
     function updateWithRaw() {

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1,0 +1,952 @@
+component extends="tests.resources.AbstractQueryBuilderSpec" {
+
+
+    private function getBuilder() {
+        variables.utils = getMockBox().createMock( "qb.models.Query.QueryUtils" ).init();
+        variables.grammar = getMockBox().createMock( "qb.models.Grammars.SQLiteGrammar" ).init( variables.utils );
+        var builder = getMockBox().createMock( "qb.models.Query.QueryBuilder" ).init( grammar );
+        return builder;
+    }
+
+    function selectAllColumns() {
+        return "SELECT * FROM ""users""";
+    }
+
+    function selectSpecificColumn() {
+        return "SELECT ""name"" FROM ""users""";
+    }
+    
+    function selectMultipleArray() {
+        return "SELECT ""name"", COUNT(*) FROM ""users""";
+    }
+
+    function addSelect() {
+        return "SELECT ""foo"", ""bar"", ""baz"", ""boom"" FROM ""users""";
+    }
+
+    function addSelectRemovesStar() {
+        return "SELECT ""foo"" FROM ""users""";
+    }
+
+    function selectDistinct() {
+        return "SELECT DISTINCT ""foo"", ""bar"" FROM ""users""";
+    }
+
+    function parseColumnAlias() {
+        return "SELECT ""foo"" AS ""bar"" FROM ""users""";
+    }
+
+    function parseColumnAliasWithQuotes() {
+        return "SELECT ""foo"" AS ""bar"" FROM ""users""";
+    }
+
+    function parseColumnAliasInWhere() {
+        return { "sql": "SELECT ""users"".""foo"" FROM ""users"" WHERE ""users"".""foo"" = ?", "bindings": [ "bar" ] };
+    }
+
+    function parseColumnAliasInWhereSubselect() {
+        return {
+            "sql": "SELECT ""u"".*, ""user_roles"".""roleid"", ""roles"".""rolecode"" FROM ""users"" AS ""u"" INNER JOIN ""user_roles"" ON ""user_roles"".""userid"" = ""u"".""userid"" LEFT JOIN ""roles"" ON ""user_roles"".""roleid"" = ""roles"".""roleid"" WHERE ""user_roles"".""roleid"" = (SELECT ""roleid"" FROM ""roles"" WHERE ""rolecode"" = ?)",
+            "bindings": [ "SYSADMIN" ]
+        };
+    }
+
+    function wrapColumnsAndAliases() {
+        return "SELECT ""x"".""y"" AS ""foo.bar"" FROM ""public"".""users""";
+    }
+
+    function selectWithRaw() {
+        return "SELECT substr( foo, 6 ) FROM ""users""";
+    }
+
+    function selectRaw() {
+        return "SELECT substr( foo, 6 ) FROM ""users""";
+    }
+
+    function selectRawArray() {
+        return "SELECT substr( foo, 6 ), trim( bar ) FROM ""users""";
+    }
+
+    function selectConcat() {
+        return "SELECT a || b || c || d AS ""my_alias"" FROM ""users""";
+    }
+
+    function selectConcatArray() {
+        return "SELECT a || b || c || d AS ""my_alias"" FROM ""users""";
+    }
+    
+    function clearSelect() {
+        return "SELECT * FROM ""users""";
+    }
+
+    function reselect() {
+        return "SELECT ""baz"" FROM ""users""";
+    }
+
+    function reselectRaw() {
+        return "SELECT substr( foo, 6 ), trim( bar ) FROM ""users""";
+    }
+
+    function subSelect() {
+        return "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"") AS ""latestUpdatedDate"" FROM ""users""";
+    }
+
+    function subSelectQueryObject() {
+        return "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ""users"".""id"") AS ""latestUpdatedDate"" FROM ""users""";
+    }
+
+    function subSelectWithBindings() {
+        return {
+            sql: "SELECT ""name"", (SELECT MAX(updated_date) FROM ""posts"" WHERE ""posts"".""user_id"" = ?) AS ""latestUpdatedDate"" FROM ""users""",
+            bindings: [ 1 ]
+        };
+    }
+
+    function from() {
+        return "SELECT * FROM ""users""";
+    }
+
+    function fromRaw() {
+        return "SELECT * FROM Test (nolock)";
+    }
+
+    function fromDerivedTable() {
+        return { sql: "SELECT * FROM (SELECT ""id"", ""name"" FROM ""users"" WHERE ""age"" >= ?) AS ""u""", bindings: [ 21 ] };
+    }
+
+    function noLock() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+    
+    function sharedLock() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+    
+    function lockForUpdate() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+    
+    function lockForUpdateSkipLocked() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+    
+    function lockArbitraryString() {
+        return { "sql": "SELECT * FROM ""users"" WHERE ""id"" = ?", "bindings": [ 1 ] };
+    }
+    
+    function table() {
+        return "SELECT * FROM ""users""";
+    }
+    
+    function tablePrefix() {
+        return "SELECT * FROM ""prefix_users""";
+    }
+
+    function tablePrefixWithAlias() {
+        return "SELECT * FROM ""prefix_users"" AS ""prefix_people""";
+    }
+
+    function columnAliasWithAs() {
+        return "SELECT ""id"" AS ""user_id"" FROM ""users""";
+    }
+
+    function columnAliasWithoutAs() {
+        return "SELECT ""id"" AS ""user_id"" FROM ""users""";
+    }
+
+    function tableAliasWithAs() {
+        return "SELECT * FROM ""users"" AS ""people""";
+    }
+
+    function tableAliasWithoutAs() {
+        return "SELECT * FROM ""users"" AS ""people""";
+    }
+
+    function basicWhere() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ?", bindings: [ 1 ] };
+    }
+
+    function basicWhereWithQueryParamStruct() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""createdDate"" >= ?", bindings: [ "01/01/2019" ] };
+    }
+
+    function orWhere() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ? OR ""email"" = ?", bindings: [ 1, "foo" ] };
+    }
+
+    function andWhere() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ? AND ""email"" = ?", bindings: [ 1, "foo" ] };
+    }
+
+    function whereRaw() {
+        return { sql: "SELECT * FROM ""users"" WHERE id = ? OR email = ?", bindings: [ 1, "foo" ] };
+    }
+
+    function orWhereRaw() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ? OR email = ?", bindings: [ 1, "foo" ] };
+    }
+
+    function whereColumn() {
+        return "SELECT * FROM ""users"" WHERE ""first_name"" = ""last_name""";
+    }
+
+    function orWhereColumn() {
+        return "SELECT * FROM ""users"" WHERE ""first_name"" = ""last_name"" OR ""updated_date"" > ""created_date""";
+    }
+
+    function whereNested() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR (""name"" = ? AND ""age"" >= ?)",
+            bindings: [ "foo", "bar", 21 ]
+        };
+    }
+
+    function whereSubselect() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" = (SELECT MAX(id) FROM ""users"" WHERE ""email"" = ?)",
+            bindings: [ "foo", "bar" ]
+        };
+    }
+
+    function whereBuilderInstance() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" = (SELECT MAX(id) FROM ""users"" WHERE ""email"" = ?)",
+            bindings: [ "foo", "bar" ]
+        };
+    }
+
+    function whereExists() {
+        return "SELECT * FROM ""orders"" WHERE EXISTS (SELECT 1 FROM ""products"" WHERE ""products"".""id"" = ""orders"".""id"")";
+    }
+
+    function orWhereExists() {
+        return {
+            sql: "SELECT * FROM ""orders"" WHERE ""id"" = ? OR EXISTS (SELECT 1 FROM ""products"" WHERE ""products"".""id"" = ""orders"".""id"")",
+            bindings: [ 1 ]
+        };
+    }
+
+    function whereNotExists() {
+        return "SELECT * FROM ""orders"" WHERE NOT EXISTS (SELECT 1 FROM ""products"" WHERE ""products"".""id"" = ""orders"".""id"")";
+    }
+
+    function orWhereNotExists() {
+        return {
+            sql: "SELECT * FROM ""orders"" WHERE ""id"" = ? OR NOT EXISTS (SELECT 1 FROM ""products"" WHERE ""products"".""id"" = ""orders"".""id"")",
+            bindings: [ 1 ]
+        };
+    }
+
+    function whereExistsBuilderInstance() {
+        return {
+            sql: "SELECT * FROM ""orders"" WHERE EXISTS (SELECT 1 FROM ""products"" WHERE ""products"".""id"" = ""orders"".""id"")",
+            bindings: []
+        };
+    }
+
+    function whereNull() {
+        return "SELECT * FROM ""users"" WHERE ""id"" IS NULL";
+    }
+
+    function orWhereNull() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ? OR ""id"" IS NULL", bindings: [ 1 ] };
+    }
+
+    function whereNotNull() {
+        return "SELECT * FROM ""users"" WHERE ""id"" IS NOT NULL";
+    }
+
+    function orWhereNotNull() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" = ? OR ""id"" IS NOT NULL", bindings: [ 1 ] };
+    }
+
+    function whereNullSubselect() {
+        return "SELECT * FROM ""users"" WHERE (SELECT MAX(created_date) FROM ""logins"" WHERE ""logins"".""user_id"" = ""users"".""id"") IS NULL";
+    }
+
+    function whereNullSubquery() {
+        return "SELECT * FROM ""users"" WHERE (SELECT MAX(created_date) FROM ""logins"" WHERE ""logins"".""user_id"" = ""users"".""id"") IS NULL";
+    }
+
+    function whereBetween() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" BETWEEN ? AND ?", bindings: [ 1, 2 ] };
+    }
+
+    function whereBetweenWithQueryParamStructs() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""createdDate"" BETWEEN ? AND ?",
+            bindings: [ "1/1/2019", "12/31/2019" ]
+        };
+    }
+
+    function whereBetweenClosures() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" BETWEEN (SELECT MIN(id) FROM ""users"" WHERE ""email"" = ?) AND (SELECT MAX(id) FROM ""users"" WHERE ""email"" = ?)",
+            bindings: [ "bar", "bar" ]
+        };
+    }
+
+    function whereBetweenBuilderInstances() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" BETWEEN (SELECT MIN(id) FROM ""users"" WHERE ""email"" = ?) AND (SELECT MAX(id) FROM ""users"" WHERE ""email"" = ?)",
+            bindings: [ "bar", "bar" ]
+        };
+    }
+
+    function whereNotBetween() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" NOT BETWEEN ? AND ?", bindings: [ 1, 2 ] };
+    }
+
+    function whereBetweenMixed() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" BETWEEN (SELECT MIN(id) FROM ""users"" WHERE ""email"" = ?) AND (SELECT MAX(id) FROM ""users"" WHERE ""email"" = ?)",
+            bindings: [ "bar", "bar" ]
+        };
+    }
+
+    function whereInList() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
+    }
+
+    function whereInArray() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
+    }
+
+    function whereInArrayOfQueryParamStructs() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
+    }
+
+    function orWhereIn() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)", bindings: [ "foo", 1, 2, 3 ] };
+    }
+
+    function whereInRaw() {
+        return "SELECT * FROM ""users"" WHERE ""id"" IN (1)";
+    }
+
+    function whereInEmpty() {
+        return "SELECT * FROM ""users"" WHERE 0 = 1";
+    }
+
+    function whereNotInEmpty() {
+        return "SELECT * FROM ""users"" WHERE 1 = 1";
+    }
+
+    function whereInSubSelect() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT ""id"" FROM ""users"" WHERE ""age"" > ?)",
+            bindings: [ 25 ]
+        };
+    }
+
+    function whereInBuilderInstance() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT ""id"" FROM ""users"" WHERE ""age"" > ?)",
+            bindings: [ 25 ]
+        };
+    }
+
+    function whereLike() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""username"" LIKE ?", bindings: [ "Jo%" ] };
+    }
+
+    function whereNotLike() {
+        return { sql: "SELECT * FROM ""users"" WHERE ""username"" NOT LIKE ?", bindings: [ "Jo%" ] };
+    }
+
+    function innerJoin() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function innerJoinRaw() {
+        return "SELECT * FROM ""users"" INNER JOIN contacts (nolock) ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function innerJoinShorthand() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function multipleJoins() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" INNER JOIN ""addresses"" AS ""a"" ON ""a"".""contact_id"" = ""contacts"".""id""";
+    }
+
+    function joinWithWhere() {
+        return { sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""contacts"".""balance"" < ?", bindings: [ 100 ] };
+    }
+
+    function leftJoin() {
+        return "SELECT * FROM ""users"" LEFT JOIN ""orders"" ON ""users"".""id"" = ""orders"".""user_id""";
+    }
+
+    function leftJoinRaw() {
+        return "SELECT * FROM ""users"" LEFT JOIN contacts (nolock) ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function leftJoinNested() {
+        return "SELECT * FROM ""users"" LEFT JOIN ""orders"" ON ""users"".""id"" = ""orders"".""user_id""";
+    }
+
+    function innerJoinCallback() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function innerJoinWithJoinInstance() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function rightJoin() {
+        return "SELECT * FROM ""orders"" RIGHT JOIN ""users"" ON ""orders"".""user_id"" = ""users"".""id""";
+    }
+
+    function rightJoinRaw() {
+        return "SELECT * FROM ""users"" RIGHT JOIN contacts (nolock) ON ""users"".""id"" = ""contacts"".""id""";
+    }
+
+    function crossJoin() {
+        return "SELECT * FROM ""sizes"" CROSS JOIN ""colors""";
+    }
+
+    function crossJoinRaw() {
+        return "SELECT * FROM ""users"" CROSS JOIN contacts (nolock)";
+    }
+
+    function complexJoin() {
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""users"".""name"" = ""contacts"".""name"" OR ""users"".""admin"" = ?",
+            bindings: [ 1 ]
+        };
+    }    
+    
+    function joinWithWhereNull() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" AND ""contacts"".""deleted_date"" IS NULL";
+    }
+
+    function joinWithOrWhereNull() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""contacts"".""deleted_date"" IS NULL";
+    }
+
+    function joinWithWhereNotNull() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" AND ""contacts"".""deleted_date"" IS NOT NULL";
+    }
+
+    function joinWithOrWhereNotNull() {
+        return "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""contacts"".""deleted_date"" IS NOT NULL";
+    }
+
+    function joinWithWhereIn() {
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" AND ""contacts"".""id"" IN (?, ?, ?)",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function joinWithOrWhereIn() {
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""contacts"".""id"" IN (?, ?, ?)",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function joinWithWhereNotIn() {
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" AND ""contacts"".""id"" NOT IN (?, ?, ?)",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function joinWithOrWhereNotIn() {
+        return {
+            sql: "SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" OR ""contacts"".""id"" NOT IN (?, ?, ?)",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function joinSub() {
+        return {
+            sql: "SELECT * FROM ""users"" AS ""u"" INNER JOIN (SELECT ""id"" FROM ""contacts"" WHERE ""id"" NOT IN (?, ?, ?)) AS ""c"" ON ""u"".""id"" = ""c"".""id""",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function leftJoinSub() {
+        return {
+            sql: "SELECT * FROM ""users"" AS ""u"" LEFT JOIN (SELECT ""id"" FROM ""contacts"" WHERE ""id"" NOT IN (?, ?, ?)) AS ""c"" ON ""u"".""id"" = ""c"".""id""",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function rightJoinSub() {
+        return {
+            sql: "SELECT * FROM ""users"" AS ""u"" RIGHT JOIN (SELECT ""id"" FROM ""contacts"" WHERE ""id"" NOT IN (?, ?, ?)) AS ""c"" ON ""u"".""id"" = ""c"".""id""",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function crossJoinSub() {
+        return {
+            sql: "SELECT * FROM ""users"" AS ""u"" CROSS JOIN (SELECT ""id"" FROM ""contacts"" WHERE ""id"" NOT IN (?, ?, ?)) AS ""c""",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function groupBy() {
+        return "SELECT * FROM ""users"" GROUP BY ""email""";
+    }
+
+    function groupByArray() {
+        return "SELECT * FROM ""users"" GROUP BY ""id"", ""email""";
+    }
+
+    function groupByRaw() {
+        return "SELECT * FROM ""users"" GROUP BY DATE(created_at)";
+    }
+
+    function havingBasic() {
+        return { sql: "SELECT * FROM ""users"" HAVING ""email"" > ?", bindings: [ 1 ] };
+    }
+
+    function havingRawExpression() {
+        return { sql: "SELECT * FROM ""users"" GROUP BY ""email"" HAVING COUNT(email) > ?", bindings: [ 1 ] };
+    }
+
+    function havingRawColumnWithBindings() {
+        return {
+            sql: "SELECT * FROM ""users"" GROUP BY ""email"" HAVING CASE WHEN active = ? THEN COUNT(email) ELSE 0 END > ?",
+            bindings: [ 1, 2 ]
+        };
+    }
+
+    function havingRawColumn() {
+        return { sql: "SELECT * FROM ""users"" GROUP BY ""email"" HAVING COUNT(email) > ?", bindings: [ 1 ] };
+    }
+
+    function havingRawValue() {
+        return {
+            sql: "SELECT COUNT(*) AS ""total"" FROM ""items"" WHERE ""department"" = ? GROUP BY ""category"" HAVING ""total"" > 3",
+            bindings: [ "popular" ]
+        };
+    }
+
+    function orderBy() {
+        return "SELECT * FROM ""users"" ORDER BY ""email"" ASC";
+    }
+
+    function orderByDesc() {
+        return "SELECT * FROM ""users"" ORDER BY ""email"" DESC";
+    }
+
+    function combinesOrderBy() {
+        return "SELECT * FROM ""users"" ORDER BY ""id"" ASC, ""email"" DESC";
+    }
+
+    function orderByRaw() {
+        return "SELECT * FROM ""users"" ORDER BY DATE(created_at)";
+    }
+
+    function orderByRawWithBindings() {
+        return { "sql": "SELECT * FROM ""users"" ORDER BY CASE WHEN id = ? THEN 1 ELSE 0 END DESC", "bindings": [ 1 ] };
+    }
+
+    function orderByWithRawBindings() {
+        return { "sql": "SELECT * FROM ""users"" ORDER BY CASE WHEN id = ? THEN 1 ELSE 0 END DESC", "bindings": [ 1 ] };
+    }
+
+    function orderByArray() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" ASC, ""favorite_color"" ASC";
+    }
+
+    function orderByClearOrders() {
+        return "SELECT * FROM ""users""";
+    }
+
+    function reorder() {
+        return "SELECT * FROM ""users"" ORDER BY ""age"" ASC";
+    }
+
+    function orderBySubselect() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") ASC";
+    }
+
+    function orderBySubselectDescending() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") DESC";
+    }
+
+    function orderByBuilderInstance() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") ASC";
+    }
+
+    function orderByBuilderInstanceDescending() {
+        return "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"") DESC";
+    }
+
+    function orderByBuilderWithBindings() {
+        return {
+            sql: "SELECT * FROM ""users"" ORDER BY (SELECT MAX(created_date) FROM ""logins"" WHERE ""users"".""id"" = ""logins"".""user_id"" AND ""created_date"" > ?) ASC",
+            bindings: [ "2020-01-01 00:00:00" ]
+        };
+    }
+
+    function orderByPipeDelimited() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" ASC, ""favorite_color"" DESC";
+    }
+
+    function orderByArrayOfArrays() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" ASC, ""favorite_color"" ASC";
+    }
+
+    function orderByArrayOfArraysIgnoringExtraValues() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" ASC, ""favorite_color"" ASC, ""height"" ASC";
+    }
+
+    function orderByComplex() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" ASC, ""favorite_color"" ASC, ""favorite_food"" DESC, ""height"" ASC, ""weight"" DESC, DATE(created_at), DATE(modified_at)";
+    }
+
+    function orderByRawInStruct() {
+        return "SELECT * FROM ""users"" ORDER BY DATE(created_at), DATE(modified_at)";
+    }
+
+    function orderByMixSimpleAndPipeDelimited() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" DESC, ""favorite_color"" ASC";
+    }
+
+    function orderByStruct() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" ASC, ""favorite_color"" DESC";
+    }
+
+    function multipleOrderByCalls() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" DESC, ""favorite_color"" DESC, ""height"" DESC, ""weight"" ASC, ""eye_color"" DESC, ""is_athletic"" DESC, DATE(created_at), DATE(modified_at)";
+    }
+
+    function orderByMixed() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" DESC, ""eye_color"" DESC, ""hair_color"" ASC, ""is_musical"" ASC, ""is_athletic"" DESC, DATE(created_at), DATE(modified_at)";
+    }
+
+    function orderByList() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" ASC, ""favorite_color"" ASC";
+    }
+
+    function orderByListDefaultDirection() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" DESC, ""favorite_color"" DESC";
+    }
+
+    function orderByListPipeDelimited() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" DESC, ""age"" DESC, ""favorite_color"" ASC";
+    }
+
+    function orderByListPipeDelimitedWithDefaultDirection() {
+        return "SELECT * FROM ""users"" ORDER BY ""last_name"" ASC, ""age"" DESC, ""favorite_color"" ASC";
+    }
+
+    function union() {
+        return {
+            sql: "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ?",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function unionOrderBy() {
+        return {
+            sql: "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ? ORDER BY ""name"" ASC",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function unionAll() {
+        return {
+            sql: "SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION ALL SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION ALL SELECT ""name"" FROM ""users"" WHERE ""id"" = ?",
+            bindings: [ 1, 2, 3 ]
+        };
+    }
+
+    function unionCount() {
+        return {
+            sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM (SELECT ""name"" FROM ""users"" WHERE ""id"" = ? UNION SELECT ""name"" FROM ""users"" WHERE ""id"" = ?) AS ""qb_aggregate_source""",
+            bindings: [ 1, 2 ]
+        };
+    }
+
+    function commonTableExpression() {
+        return {
+            sql: "WITH ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
+    function commonTableExpressionWithRecursiveWithColumns() {
+        return {
+            sql: "WITH RECURSIVE ""UsersCTE"" (""usersId"",""contactsId"") AS (SELECT ""users"".""id"" AS ""usersId"", ""contacts"".""id"" AS ""contactsId"" FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
+    function commonTableExpressionWithRecursive() {
+        return {
+            sql: "WITH RECURSIVE ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ 25, 1, 2 ]
+        };
+    }
+
+    function commonTableExpressionMultipleCTEsWithRecursive() {
+        return {
+            sql: "WITH RECURSIVE ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?), ""OrderCTE"" AS (SELECT * FROM ""orders"" WHERE ""created"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ 25, "2018-04-30", 1, 2 ]
+        };
+    }
+
+    function commonTableExpressionBindingOrder() {
+        return {
+            sql: "WITH RECURSIVE ""OrderCTE"" AS (SELECT * FROM ""orders"" WHERE ""created"" > ?), ""UsersCTE"" AS (SELECT * FROM ""users"" INNER JOIN ""contacts"" ON ""users"".""id"" = ""contacts"".""id"" WHERE ""users"".""age"" > ?) SELECT * FROM ""UsersCTE"" WHERE ""user"".""id"" NOT IN (?, ?)",
+            bindings: [ "2018-04-30", 25, 1, 2 ]
+        };
+    }
+
+    function limit() {
+        return "SELECT * FROM ""users"" LIMIT 3";
+    }
+
+    function take() {
+        return "SELECT * FROM ""users"" LIMIT 1";
+    }
+
+    function offset() {
+        return "SELECT * FROM ""users"" LIMIT -1 OFFSET 3";
+    }
+
+    function offsetWithOrderBy() {
+        return "SELECT * FROM ""users"" ORDER BY ""id"" ASC LIMIT -1 OFFSET 3";
+    }
+
+    function forPage() {
+        return "SELECT * FROM ""users"" LIMIT 15 OFFSET 30";
+    }
+
+    function forPageWithLessThanZeroValues() {
+        return "SELECT * FROM ""users"" LIMIT 0 OFFSET 0";
+    }
+
+    function reset() {
+        return "SELECT * FROM ""otherTable""";
+    }
+
+    function insertSingleColumn() {
+        return { sql: "INSERT INTO ""users"" (""email"") VALUES (?)", bindings: [ "foo" ] };
+    }
+
+    function insertMultipleColumns() {
+        return { sql: "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?)", bindings: [ "foo", "bar" ] };
+    }
+
+    function batchInsert() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?), (?, ?)",
+            bindings: [ "foo", "bar", "baz", "bleh" ]
+        };
+    }
+
+    function returning() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?) RETURNING ""id""",
+            bindings: [ "foo", "bar" ]
+        };
+    }
+
+    function returningIgnoresTableQualifiers() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?) RETURNING ""id""",
+            bindings: [ "foo", "bar" ]
+        };
+    }
+
+    function insertWithRaw() {
+        return {
+            sql: "INSERT INTO ""users"" (""created_date"", ""email"") VALUES (now(), ?)",
+            bindings: [ "john@example.com" ]
+        };
+    }
+
+    function insertWithNull() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""optional_field"") VALUES (?, ?)",
+            bindings: [ "john@example.com", "NULL" ]
+        };
+    }
+
+    function insertUsingSelectCallback() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""createdDate"") SELECT ""email"", ""createdDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ?",
+            bindings: [ 1 ]
+        };
+    }
+
+    function insertUsingSelectBuilder() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""createdDate"") SELECT ""email"", ""createdDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ?",
+            bindings: [ 1 ]
+        };
+    }
+
+    function insertUsingDerivingColumnNames() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""createdDate"") SELECT ""email"", ""modifiedDate"" AS ""createdDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ?",
+            bindings: [ 1 ]
+        };
+    }
+
+    function insertUsingDerivedColumnNamesFromRawStatements() {
+        return {
+            sql: "INSERT INTO ""users"" (""email"", ""createdDate"") SELECT ""email"", COALESCE(modifiedDate, NOW()) AS createdDate FROM ""activeDirectoryUsers"" WHERE ""active"" = ?",
+            bindings: [ 1 ]
+        };
+    }
+
+    function insertIgnore() {
+        return {
+            sql: "INSERT OR IGNORE INTO ""users"" (""email"", ""name"") VALUES (?, ?), (?, ?)",
+            bindings: [ "foo", "bar", "baz", "bleh" ]
+        };
+    }
+
+    function updateAllRecords() {
+        return { sql: "UPDATE ""users"" SET ""email"" = ?, ""name"" = ?", bindings: [ "foo", "bar" ] };
+    }
+
+    function updateWithWhere() {
+        return { sql: "UPDATE ""users"" SET ""email"" = ?, ""name"" = ? WHERE ""Id"" = ?", bindings: [ "foo", "bar", 1 ] };
+    }
+
+    function updateWithRaw() {
+        return { sql: "UPDATE ""hits"" SET ""count"" = count + 1 WHERE ""page"" = ?", bindings: [ "someUrl" ] };
+    }
+
+    function addUpdate() {
+        return {
+            sql: "UPDATE ""users"" SET ""email"" = ?, ""foo"" = ?, ""name"" = ? WHERE ""Id"" = ?",
+            bindings: [ "foo", "yes", "bar", 1 ]
+        };
+    }
+
+    function updateWithJoin() {
+        return "UPDATE ""employees"" SET ""departmentName"" = departments.name FROM ""employees"" INNER JOIN ""departments"" ON ""departments"".""id"" = ""employees"".""departmentId""";
+    }
+
+    function updateWithJoinAndAliases() {
+        return "UPDATE ""employees"" AS ""e"" SET ""departmentName"" = d.name FROM ""employees"" AS ""e"" INNER JOIN ""departments"" AS ""d"" ON ""d"".""id"" = ""e"".""departmentId""";
+    }
+
+    function updateWithJoinAndWhere() {
+        return {
+            sql: "UPDATE ""employees"" SET ""departmentName"" = departments.name FROM ""employees"" INNER JOIN ""departments"" ON ""departments"".""id"" = ""employees"".""departmentId"" WHERE ""departments"".""active"" = ?",
+            bindings: [ 1 ]
+        };
+    }
+
+    function updateWithSubselect() {
+        return "UPDATE ""employees"" SET ""departmentName"" = (SELECT ""name"" FROM ""departments"" WHERE ""employees"".""departmentId"" = ""departments"".""id"")";
+    }
+
+    function updateWithBuilder() {
+        return "UPDATE ""employees"" SET ""departmentName"" = (SELECT ""name"" FROM ""departments"" WHERE ""employees"".""departmentId"" = ""departments"".""id"")";
+    }
+
+    function updateOrInsertNotExists() {
+        return { sql: "INSERT INTO ""users"" (""name"") VALUES (?)", bindings: [ "baz" ] };
+    }
+
+    function updateOrInsertExists() {
+        return { sql: "UPDATE ""users"" SET ""name"" = ? WHERE ""email"" = ? LIMIT 1", bindings: [ "baz", "foo" ] };
+    }
+
+    function upsert() {
+        return {
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            bindings: [
+                1,
+                "2021-09-08 12:00:00",
+                "2021-09-08 12:00:00",
+                "foo"
+            ]
+        };
+    }
+
+    function upsertAllValues() {
+        return {
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""createdDate"" = EXCLUDED.""createdDate"", ""modifiedDate"" = EXCLUDED.""modifiedDate"", ""username"" = EXCLUDED.""username""",
+            bindings: [
+                1,
+                "2021-09-08 12:00:00",
+                "2021-09-08 12:00:00",
+                "foo"
+            ]
+        };
+    }
+
+    function upsertEmptyUpdate() {
+        return {
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?)",
+            bindings: [
+                1,
+                "2021-09-08 12:00:00",
+                "2021-09-08 12:00:00",
+                "foo"
+            ]
+        };
+    }
+
+    function upsertWithInsertedValue() {
+        return {
+            sql: "INSERT INTO ""stats"" (""postId"", ""viewedDate"", ""views"") VALUES (?, ?, ?), (?, ?, ?) ON CONFLICT (""postId"", ""viewedDate"") DO UPDATE SET ""views"" = stats.views + 1",
+            bindings: [
+                1,
+                "2021-09-08",
+                1,
+                2,
+                "2021-09-08",
+                1
+            ]
+        };
+    }
+
+    function upsertSingleTarget() {
+        return {
+            sql: "INSERT INTO ""users"" (""active"", ""createdDate"", ""modifiedDate"", ""username"") VALUES (?, ?, ?, ?) ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            bindings: [
+                1,
+                "2021-09-08 12:00:00",
+                "2021-09-08 12:00:00",
+                "foo"
+            ]
+        };
+    }
+
+    function upsertFromClosure() {
+        return {
+            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            bindings: [ 1 ]
+        };
+    }
+
+    function upsertFromBuilder() {
+        return {
+            sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",
+            bindings: [ 1 ]
+        };
+    }
+
+    function upsertWithDelete() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function deleteAll() {
+        return "DELETE FROM ""users""";
+    }
+
+    function deleteById() {
+        return { sql: "DELETE FROM ""users"" WHERE ""id"" = ?", bindings: [ 1 ] };
+    }
+
+    function deleteWhere() {
+        return { sql: "DELETE FROM ""users"" WHERE ""email"" = ?", bindings: [ "foo" ] };
+    }
+
+}

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -612,6 +612,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function cteInsertUsing() {
+        return {
+            sql: ";WITH [UsersCTE] AS (SELECT * FROM [users] WHERE [users].[age] > ?) INSERT INTO [oldUsers] ([fname], [lname], [username], [age]) SELECT [fname], [lname], [username], [age] FROM [UsersCTE]",
+            bindings: [ 25 ]
+        };
+    }
+
     function limit() {
         return "SELECT TOP (3) * FROM [users]";
     }

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -562,6 +562,13 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function unionCount() {
+        return {
+            sql: "SELECT COALESCE(COUNT(*), 0) AS ""aggregate"" FROM (SELECT [name] FROM [users] WHERE [id] = ? UNION SELECT [name] FROM [users] WHERE [id] = ?) AS [qb_aggregate_source]",
+            bindings: [ 1, 2 ]
+        };
+    }
+
     function commonTableExpression() {
         return {
             sql: ";WITH [UsersCTE] AS (SELECT * FROM [users] INNER JOIN [contacts] ON [users].[id] = [contacts].[id] WHERE [users].[age] > ?) SELECT * FROM [UsersCTE] WHERE [user].[id] NOT IN (?, ?)",

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -59,6 +59,14 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT substr( foo, 6 ), trim( bar ) FROM [users]";
     }
 
+    function selectConcat() {
+        return "SELECT CONCAT(a,b,c,d) AS [my_alias] FROM [users]";
+    }
+
+    function selectConcatArray() {
+        return "SELECT CONCAT(a,b,c,d) AS [my_alias] FROM [users]";
+    }
+
     function clearSelect() {
         return "SELECT * FROM [users]";
     }

--- a/tests/specs/SQLCommenterSpec.cfc
+++ b/tests/specs/SQLCommenterSpec.cfc
@@ -1,0 +1,74 @@
+component extends="testbox.system.BaseSpec" {
+
+    function beforeAll() {
+        variables.sqlCommenter = new qb.models.SQLCommenter.SQLCommenter();
+    }
+
+    function run() {
+        describe( "SQLCommenter", () => {
+            describe( "containsSQLComment", () => {
+                it( "can detect if a SQL statement has a comment in it", function() {
+                    makePublic( variables.sqlCommenter, "containsSQLComment", "containsSQLCommentPublic" );
+                    expect(
+                        variables.sqlCommenter.containsSQLCommentPublic( "SELECT * /* should not use star */ FROM users" )
+                    ).toBeTrue();
+                    expect( variables.sqlCommenter.containsSQLCommentPublic( "SELECT * FROM users" ) ).toBeFalse();
+                } );
+            } );
+
+            describe( "serializeValue", () => {
+                it( "can serialize values in a key value pair", function() {
+                    makePublic( variables.sqlCommenter, "serializeValue", "serializeValuePublic" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "DROP TABLE FOO" ) ).toBe( "'DROP%20TABLE%20FOO'" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "/param first" ) ).toBe( "'%2Fparam%20first'" );
+                    expect( variables.sqlCommenter.serializeValuePublic( "1234" ) ).toBe( "'1234'" );
+                } );
+            } );
+
+            describe( "serializeComment", () => {
+                it( "can serialize key value pair comments", function() {
+                    makePublic( variables.sqlCommenter, "serializeComment", "serializeCommentPublic" );
+                    expect( variables.sqlCommenter.serializeCommentPublic( "route", "/polls 1000" ) ).toBe( "route='%2Fpolls%201000'" );
+                    expect( variables.sqlCommenter.serializeCommentPublic( "name''", """DROP TABLE USERS'""" ) ).toBe( "name%27%27='%22DROP%20TABLE%20USERS%27%22'" );
+                } );
+            } );
+
+            describe( "appendCommentsToSQL", () => {
+                it( "serializes comments on the end of a sql query", function() {
+                    var commentedSQL = variables.sqlCommenter.appendCommentsToSQL(
+                        sql = "SELECT * FROM foo",
+                        comments = {
+                            "event": "Main.index",
+                            "framework": "coldbox-6.0.0",
+                            "handler": "Main",
+                            "action": "index",
+                            "route": "/",
+                            "dbDriver": "mysql-connector-java-8.0.25 (Revision: 08be9e9b4cba6aa115f9b27b215887af40b159e0)"
+                        }
+                    );
+
+                    expect( commentedSQL ).toBeWithCase(
+                        "SELECT * FROM foo /*action='index',dbDriver='mysql-connector-java-8.0.25%20%28Revision%3A%2008be9e9b4cba6aa115f9b27b215887af40b159e0%29',event='Main.index',framework='coldbox-6.0.0',handler='Main',route='%2F'*/"
+                    );
+                } );
+            } );
+
+            describe( "parseCommentedSQL", () => {
+                it( "can parse a commented SQL string into the sql and the comments", function() {
+                    var commentedSQL = "SELECT * FROM foo /*action='index',dbDriver='mysql-connector-java-8.0.25%20%28Revision%3A%2008be9e9b4cba6aa115f9b27b215887af40b159e0%29',event='Main.index',framework='coldbox-6.0.0',handler='Main',route='%2F'*/";
+                    var sqlAndComments = variables.sqlCommenter.parseCommentedSQL( commentedSQL );
+                    expect( sqlAndComments.sql ).toBeWithCase( "SELECT * FROM foo" );
+                    expect( sqlAndComments.comments ).toBe( {
+                        "event": "Main.index",
+                        "framework": "coldbox-6.0.0",
+                        "handler": "Main",
+                        "action": "index",
+                        "route": "/",
+                        "dbDriver": "mysql-connector-java-8.0.25 (Revision: 08be9e9b4cba6aa115f9b27b215887af40b159e0)"
+                    } );
+                } );
+            } );
+        } );
+    }
+
+}

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -108,6 +108,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `employees` (`salary` FLOAT(3,2) NOT NULL)" ];
     }
 
+    function guid() {
+        return [ "CREATE TABLE `users` (`id` NCHAR(36) NOT NULL)" ];
+    }
+
     function increments() {
         return [
             "CREATE TABLE `users` (`id` INTEGER UNSIGNED NOT NULL AUTO_INCREMENT, CONSTRAINT `pk_users_id` PRIMARY KEY (`id`))"
@@ -329,7 +333,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uuid() {
-        return [ "CREATE TABLE `users` (`id` NCHAR(36) NOT NULL)" ];
+        return [ "CREATE TABLE `users` (`id` NCHAR(35) NOT NULL)" ];
     }
 
     function comment() {

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -417,6 +417,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "ALTER TABLE `users` DROP FOREIGN KEY `fk_posts_author_id`" ];
     }
 
+    function dropIndexFromName() {
+        return [ "ALTER TABLE `users` DROP INDEX `idx_username`" ];
+    }
+
+    function dropIndexFromIndex() {
+        return [ "ALTER TABLE `users` DROP INDEX `idx_users_username`" ];
+    }
+
     function basicIndex() {
         return [
             "CREATE TABLE `users` (`published_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, INDEX `idx_users_published_date` (`published_date`))"

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -114,6 +114,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""EMPLOYEES"" (""SALARY"" FLOAT NOT NULL)" ];
     }
 
+    function guid() {
+        return [ "CREATE TABLE ""USERS"" (""ID"" CHAR(36) NOT NULL)" ];
+    }
+
     function increments() {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
@@ -339,7 +343,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uuid() {
-        return [ "CREATE TABLE ""USERS"" (""ID"" CHAR(36) NOT NULL)" ];
+        return [ "CREATE TABLE ""USERS"" (""ID"" CHAR(35) NOT NULL)" ];
     }
 
     function comment() {

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -438,6 +438,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "ALTER TABLE ""USERS"" DROP CONSTRAINT ""FK_POSTS_AUTHOR_ID""" ];
     }
 
+    function dropIndexFromName() {
+        return [ "ALTER TABLE ""USERS"" DROP CONSTRAINT ""IDX_USERNAME""" ];
+    }
+
+    function dropIndexFromIndex() {
+        return [ "ALTER TABLE ""USERS"" DROP CONSTRAINT ""IDX_USERS_USERNAME""" ];
+    }
+
     function basicIndex() {
         return [
             "CREATE TABLE ""USERS"" (""PUBLISHED_DATE"" DATE NOT NULL)",

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -415,6 +415,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "ALTER TABLE ""users"" DROP CONSTRAINT ""fk_posts_author_id""" ];
     }
 
+    function dropIndexFromName() {
+        return [ "DROP INDEX ""idx_username""" ];
+    }
+
+    function dropIndexFromIndex() {
+        return [ "DROP INDEX ""idx_users_username""" ];
+    }
+
     function basicIndex() {
         return [
             "CREATE TABLE ""users"" (""published_date"" TIMESTAMP NOT NULL)",

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -109,6 +109,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""employees"" (""salary"" DECIMAL(3,2) NOT NULL)" ];
     }
 
+    function guid() {
+        return [ "CREATE TABLE ""users"" (""id"" CHAR(36) NOT NULL)" ];
+    }
+
     function increments() {
         return [ "CREATE TABLE ""users"" (""id"" SERIAL NOT NULL, CONSTRAINT ""pk_users_id"" PRIMARY KEY (""id""))" ];
     }
@@ -318,7 +322,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uuid() {
-        return [ "CREATE TABLE ""users"" (""id"" CHAR(36) NOT NULL)" ];
+        return [ "CREATE TABLE ""users"" (""id"" CHAR(35) NOT NULL)" ];
     }
 
     function comment() {

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -15,15 +15,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function columnPrimaryKey() {
-        return [
-            "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))"
-        ];
+        return [ "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))" ];
     }
 
     function tablePrimaryKey() {
-        return [
-            "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))"
-        ];
+        return [ "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))" ];
     }
 
     function simpleTable() {
@@ -31,7 +27,9 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function hasTable() {
-        return [ "SELECT 1 FROM ""pragma_table_list"" WHERE ""type"" = 'table' AND ""name"" = ? AND ""schema"" = 'main'" ];
+        return [
+            "SELECT 1 FROM ""pragma_table_list"" WHERE ""type"" = 'table' AND ""name"" = ? AND ""schema"" = 'main'"
+        ];
     }
 
     function hasTableInSchema() {
@@ -39,7 +37,9 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function hasColumn() {
-        return [ "SELECT 1 FROM ""pragma_table_list"" tl JOIN pragma_table_info(tl.name) ti WHERE tl.""type"" = 'table' AND tl.""name"" = ? AND ti.""name"" = ? AND tl.""schema"" = 'main'" ];
+        return [
+            "SELECT 1 FROM ""pragma_table_list"" tl JOIN pragma_table_info(tl.name) ti WHERE tl.""type"" = 'table' AND tl.""name"" = ? AND ti.""name"" = ? AND tl.""schema"" = 'main'"
+        ];
     }
 
     function hasColumnInSchema() {
@@ -77,17 +77,21 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     function char() {
         return [ "CREATE TABLE ""classifications"" (""level"" VARCHAR(1) NOT NULL)" ];
     }
-    
+
     function charWithLength() {
         return [ "CREATE TABLE ""classifications"" (""abbreviation"" VARCHAR(3) NOT NULL)" ];
     }
 
     function computedStored() {
-        return [ "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) STORED NOT NULL)" ];
+        return [
+            "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) STORED NOT NULL)"
+        ];
     }
 
     function computedVirtual() {
-        return [ "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) VIRTUAL NOT NULL)" ];
+        return [
+            "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) VIRTUAL NOT NULL)"
+        ];
     }
 
     function date() {
@@ -119,7 +123,9 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function enum() {
-        return [ "CREATE TABLE ""employees"" (""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL')))" ];
+        return [
+            "CREATE TABLE ""employees"" (""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL')))"
+        ];
     }
 
     function float() {
@@ -167,9 +173,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function mediumIncrements() {
-        return [
-            "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)"
-        ];
+        return [ "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)" ];
     }
 
     function mediumInteger() {
@@ -192,7 +196,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""transactions"" (""amount"" INTEGER NOT NULL)" ];
     }
 
-    
+
     function morphs() {
         return [
             "CREATE TABLE ""tags"" (""taggable_id"" INTEGER NOT NULL, ""taggable_type"" TEXT NOT NULL)",
@@ -302,9 +306,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function tinyIncrements() {
-        return [
-            "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)"
-        ];
+        return [ "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)" ];
     }
 
     function tinyInteger() {
@@ -406,9 +408,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uniqueOverridingName() {
-        return [
-            "CREATE TABLE ""users"" (""username"" TEXT NOT NULL, CONSTRAINT ""unq_uname"" UNIQUE (""username""))"
-        ];
+        return [ "CREATE TABLE ""users"" (""username"" TEXT NOT NULL, CONSTRAINT ""unq_uname"" UNIQUE (""username""))" ];
     }
 
     function uniqueMultipleColumns() {
@@ -430,17 +430,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     function renameConstraint() {
         return { exception: "UnsupportedOperation" };
     }
-    
+
     function dropConstraintFromName() {
-        return [
-            "DROP INDEX ""unique_username"""
-        ];
+        return [ "DROP INDEX ""unique_username""" ];
     }
 
     function dropConstraintFromIndex() {
-        return [
-            "DROP INDEX ""unq_users_username"""
-        ];
+        return [ "DROP INDEX ""unq_users_username""" ];
     }
 
     function dropForeignKey() {
@@ -527,7 +523,9 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function addColumn() {
-        return [ "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL'))" ];
+        return [
+            "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL'))"
+        ];
     }
 
     function addMultiple() {

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -1,0 +1,591 @@
+component extends="tests.resources.AbstractSchemaBuilderSpec" {
+
+    function emptyTable() {
+        return [ "CREATE TABLE ""users"" ()" ];
+    }
+
+    function complicatedTable() {
+        return [
+            "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ""username"" TEXT NOT NULL, ""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL, ""password"" TEXT NOT NULL, ""country_id"" INTEGER NOT NULL, ""created_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, ""modified_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (""country_id"") REFERENCES ""countries"" (""id"") ON UPDATE NO ACTION ON DELETE CASCADE)"
+        ];
+    }
+
+    function complicatedModify() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function columnPrimaryKey() {
+        return [
+            "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))"
+        ];
+    }
+
+    function tablePrimaryKey() {
+        return [
+            "CREATE TABLE ""users"" (""uuid"" TEXT NOT NULL, PRIMARY KEY (""uuid""))"
+        ];
+    }
+
+    function simpleTable() {
+        return [ "CREATE TABLE ""users"" (""username"" TEXT NOT NULL, ""password"" TEXT NOT NULL)" ];
+    }
+
+    function hasTable() {
+        return [ "SELECT 1 FROM ""pragma_table_list"" WHERE ""type"" = 'table' AND ""name"" = ? AND ""schema"" = 'main'" ];
+    }
+
+    function hasTableInSchema() {
+        return [ "SELECT 1 FROM ""pragma_table_list"" WHERE ""type"" = 'table' AND ""name"" = ? AND ""schema"" = ?" ];
+    }
+
+    function hasColumn() {
+        return [ "SELECT 1 FROM ""pragma_table_list"" tl JOIN pragma_table_info(tl.name) ti WHERE tl.""type"" = 'table' AND tl.""name"" = ? AND ti.""name"" = ? AND tl.""schema"" = 'main'" ];
+    }
+
+    function hasColumnInSchema() {
+        return [
+            "SELECT 1 FROM ""pragma_table_list"" tl JOIN pragma_table_info(tl.name) ti WHERE tl.""type"" = 'table' AND tl.""name"" = ? AND ti.""name"" = ? AND tl.""schema"" = ?"
+        ];
+    }
+
+    // Column Types
+
+    function bigIncrements() {
+        return [ "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)" ];
+    }
+
+    function bigInteger() {
+        return [ "CREATE TABLE ""weather_reports"" (""temperature"" BIGINT NOT NULL)" ];
+    }
+
+    function bigIntegerWithPrecision() {
+        return [ "CREATE TABLE ""weather_reports"" (""temperature"" BIGINT NOT NULL)" ];
+    }
+
+    function bit() {
+        return [ "CREATE TABLE ""users"" (""active"" BOOLEAN NOT NULL)" ];
+    }
+
+    function bitWithLength() {
+        return [ "CREATE TABLE ""users"" (""something"" BOOLEAN NOT NULL)" ];
+    }
+
+    function boolean() {
+        return [ "CREATE TABLE ""users"" (""active"" BOOLEAN NOT NULL)" ];
+    }
+
+    function char() {
+        return [ "CREATE TABLE ""classifications"" (""level"" VARCHAR(1) NOT NULL)" ];
+    }
+    
+    function charWithLength() {
+        return [ "CREATE TABLE ""classifications"" (""abbreviation"" VARCHAR(3) NOT NULL)" ];
+    }
+
+    function computedStored() {
+        return [ "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) STORED NOT NULL)" ];
+    }
+
+    function computedVirtual() {
+        return [ "CREATE TABLE ""products"" (""price"" INTEGER NOT NULL, ""tax"" INTEGER GENERATED ALWAYS AS (price * 0.0675) VIRTUAL NOT NULL)" ];
+    }
+
+    function date() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" DATE NOT NULL)" ];
+    }
+
+    function datetime() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" DATETIME NOT NULL)" ];
+    }
+
+    function datetimetz() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" DATETIME NOT NULL)" ];
+    }
+
+    function decimal() {
+        return [ "CREATE TABLE ""employees"" (""salary"" DECIMAL(10,0) NOT NULL)" ];
+    }
+
+    function decimalWithLength() {
+        return [ "CREATE TABLE ""employees"" (""salary"" DECIMAL(3,0) NOT NULL)" ];
+    }
+
+    function decimalWithPrecision() {
+        return [ "CREATE TABLE ""employees"" (""salary"" DECIMAL(10,2) NOT NULL)" ];
+    }
+
+    function decimalWithLengthAndPrecision() {
+        return [ "CREATE TABLE ""employees"" (""salary"" DECIMAL(3,2) NOT NULL)" ];
+    }
+
+    function enum() {
+        return [ "CREATE TABLE ""employees"" (""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL')))" ];
+    }
+
+    function float() {
+        return [ "CREATE TABLE ""employees"" (""salary"" FLOAT(10,0) NOT NULL)" ];
+    }
+
+    function floatWithLength() {
+        return [ "CREATE TABLE ""employees"" (""salary"" FLOAT(3,0) NOT NULL)" ];
+    }
+
+    function floatWithPrecision() {
+        return [ "CREATE TABLE ""employees"" (""salary"" FLOAT(10,2) NOT NULL)" ];
+    }
+
+    function floatWithLengthAndPrecision() {
+        return [ "CREATE TABLE ""employees"" (""salary"" FLOAT(3,2) NOT NULL)" ];
+    }
+
+    function increments() {
+        return [ "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)" ];
+    }
+
+    function integer() {
+        return [ "CREATE TABLE ""users"" (""age"" INTEGER NOT NULL)" ];
+    }
+
+    function integerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" INTEGER NOT NULL)" ];
+    }
+
+    function json() {
+        return [ "CREATE TABLE ""users"" (""personalizations"" TEXT NOT NULL)" ];
+    }
+
+    function lineString() {
+        return [ "CREATE TABLE ""users"" (""positions"" TEXT NOT NULL)" ];
+    }
+
+    function longText() {
+        return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function UnicodeLongText() {
+        return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function mediumIncrements() {
+        return [
+            "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)"
+        ];
+    }
+
+    function mediumInteger() {
+        return [ "CREATE TABLE ""users"" (""age"" MEDIUMINT NOT NULL)" ];
+    }
+
+    function mediumIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" MEDIUMINT NOT NULL)" ];
+    }
+
+    function mediumText() {
+        return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function money() {
+        return [ "CREATE TABLE ""transactions"" (""amount"" INTEGER NOT NULL)" ];
+    }
+
+    function smallMoney() {
+        return [ "CREATE TABLE ""transactions"" (""amount"" INTEGER NOT NULL)" ];
+    }
+
+    
+    function morphs() {
+        return [
+            "CREATE TABLE ""tags"" (""taggable_id"" INTEGER NOT NULL, ""taggable_type"" TEXT NOT NULL)",
+            "CREATE INDEX ""taggable_index"" ON ""tags"" (""taggable_id"", ""taggable_type"")"
+        ];
+    }
+
+    function nullableMorphs() {
+        return [
+            "CREATE TABLE ""tags"" (""taggable_id"" INTEGER, ""taggable_type"" TEXT)",
+            "CREATE INDEX ""taggable_index"" ON ""tags"" (""taggable_id"", ""taggable_type"")"
+        ];
+    }
+
+    function nullableTimestamps() {
+        return [ "CREATE TABLE ""posts"" (""createdDate"" TEXT, ""modifiedDate"" TEXT)" ];
+    }
+
+    function point() {
+        return [ "CREATE TABLE ""users"" (""position"" TEXT NOT NULL)" ];
+    }
+
+    function polygon() {
+        return [ "CREATE TABLE ""users"" (""positions"" TEXT NOT NULL)" ];
+    }
+
+    function raw() {
+        return [ "CREATE TABLE ""users"" (id BLOB NOT NULL)" ];
+    }
+
+    function rawInAlter() {
+        return [
+            "ALTER TABLE ""registrars"" ADD COLUMN HasDNSSecAPI bit NOT NULL CONSTRAINT DF_registrars_HasDNSSecAPI DEFAULT (0)"
+        ];
+    }
+
+    function smallIncrements() {
+        return [ "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)" ];
+    }
+
+    function smallInteger() {
+        return [ "CREATE TABLE ""users"" (""age"" SMALLINT NOT NULL)" ];
+    }
+
+    function smallIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" SMALLINT NOT NULL)" ];
+    }
+
+    function softDeletes() {
+        return [ "CREATE TABLE ""posts"" (""deletedDate"" TEXT)" ];
+    }
+
+    function softDeletesTz() {
+        return [ "CREATE TABLE ""posts"" (""deletedDate"" TEXT)" ];
+    }
+
+    function string() {
+        return [ "CREATE TABLE ""users"" (""username"" TEXT NOT NULL)" ];
+    }
+
+    function unicodeString() {
+        return [ "CREATE TABLE ""users"" (""username"" TEXT NOT NULL)" ];
+    }
+
+    function stringWithLength() {
+        return [ "CREATE TABLE ""users"" (""password"" TEXT NOT NULL)" ];
+    }
+
+    function text() {
+        return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function unicodeText() {
+        return [ "CREATE TABLE ""posts"" (""body"" TEXT NOT NULL)" ];
+    }
+
+    function time() {
+        return [ "CREATE TABLE ""recurring_tasks"" (""fire_time"" TEXT NOT NULL)" ];
+    }
+
+    function timeTz() {
+        return [ "CREATE TABLE ""recurring_tasks"" (""fire_time"" TEXT NOT NULL)" ];
+    }
+
+    function timestamp() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
+    }
+
+    function timestampWithNullable() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT)" ];
+    }
+
+    function timestamps() {
+        return [
+            "CREATE TABLE ""posts"" (""createdDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, ""modifiedDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+        ];
+    }
+
+    function timestampTz() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
+    }
+
+    function timestampsTz() {
+        return [
+            "CREATE TABLE ""posts"" (""createdDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, ""modifiedDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+        ];
+    }
+
+    function tinyIncrements() {
+        return [
+            "CREATE TABLE ""users"" (""id"" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)"
+        ];
+    }
+
+    function tinyInteger() {
+        return [ "CREATE TABLE ""users"" (""active"" TINYINT NOT NULL)" ];
+    }
+
+    function tinyIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""active"" TINYINT NOT NULL)" ];
+    }
+
+    function unsignedBigInteger() {
+        return [ "CREATE TABLE ""employees"" (""salary"" BIGINT NOT NULL)" ];
+    }
+
+    function unsignedBigIntegerWithPrecision() {
+        return [ "CREATE TABLE ""employees"" (""salary"" BIGINT NOT NULL)" ];
+    }
+
+    function unsignedinteger() {
+        return [ "CREATE TABLE ""users"" (""age"" INTEGER NOT NULL)" ];
+    }
+
+    function unsignedintegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" INTEGER NOT NULL)" ];
+    }
+
+    function unsignedMediumInteger() {
+        return [ "CREATE TABLE ""users"" (""age"" MEDIUMINT NOT NULL)" ];
+    }
+
+    function unsignedMediumIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" MEDIUMINT NOT NULL)" ];
+    }
+
+    function unsignedSmallInteger() {
+        return [ "CREATE TABLE ""users"" (""age"" SMALLINT NOT NULL)" ];
+    }
+
+    function unsignedSmallIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" SMALLINT NOT NULL)" ];
+    }
+
+    function unsignedTinyInteger() {
+        return [ "CREATE TABLE ""users"" (""age"" TINYINT NOT NULL)" ];
+    }
+
+    function unsignedTinyIntegerWithPrecision() {
+        return [ "CREATE TABLE ""users"" (""age"" TINYINT NOT NULL)" ];
+    }
+
+    function uuid() {
+        return [ "CREATE TABLE ""users"" (""id"" VARCHAR(35) NOT NULL)" ];
+    }
+
+    function guid() {
+        return [ "CREATE TABLE ""users"" (""id"" VARCHAR(36) NOT NULL)" ];
+    }
+
+    function comment() {
+        return [ "CREATE TABLE ""users"" (""active"" BOOLEAN NOT NULL)" ];
+    }
+
+    function defaultForChar() {
+        return [ "CREATE TABLE ""users"" (""active"" VARCHAR(1) NOT NULL DEFAULT 'Y')" ];
+    }
+
+    function defaultForBoolean() {
+        return [ "CREATE TABLE ""users"" (""active"" BOOLEAN NOT NULL DEFAULT 1)" ];
+    }
+
+    function defaultForNumber() {
+        return [ "CREATE TABLE ""users"" (""experience"" INTEGER NOT NULL DEFAULT 100)" ];
+    }
+
+    function defaultForString() {
+        return [ "CREATE TABLE ""users"" (""country"" TEXT NOT NULL DEFAULT 'USA')" ];
+    }
+
+    function timestampWithCurrent() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
+    }
+
+    function nullable() {
+        return [ "CREATE TABLE ""users"" (""id"" VARCHAR(36))" ];
+    }
+
+    function unsigned() {
+        return [ "CREATE TABLE ""users"" (""age"" INTEGER NOT NULL)" ];
+    }
+
+    function columnUnique() {
+        return [ "CREATE TABLE ""users"" (""username"" TEXT NOT NULL UNIQUE)" ];
+    }
+
+    function tableUnique() {
+        return [
+            "CREATE TABLE ""users"" (""username"" TEXT NOT NULL, CONSTRAINT ""unq_users_username"" UNIQUE (""username""))"
+        ];
+    }
+
+    function uniqueOverridingName() {
+        return [
+            "CREATE TABLE ""users"" (""username"" TEXT NOT NULL, CONSTRAINT ""unq_uname"" UNIQUE (""username""))"
+        ];
+    }
+
+    function uniqueMultipleColumns() {
+        return [
+            "CREATE TABLE ""users"" (""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL, CONSTRAINT ""unq_users_first_name_last_name"" UNIQUE (""first_name"", ""last_name""))"
+        ];
+    }
+
+    function addConstraint() {
+        return [ "CREATE UNIQUE INDEX ""unq_users_username"" ON ""users""(""username"")" ];
+    }
+
+    function addMultipleConstraints() {
+        return [
+            "CREATE UNIQUE INDEX ""unq_users_username"" ON ""users""(""username"")",
+            "CREATE UNIQUE INDEX ""unq_users_email"" ON ""users""(""email"")"
+        ];
+    }
+    function renameConstraint() {
+        return { exception: "UnsupportedOperation" };
+    }
+    
+    function dropConstraintFromName() {
+        return [
+            "DROP INDEX ""unique_username"""
+        ];
+    }
+
+    function dropConstraintFromIndex() {
+        return [
+            "DROP INDEX ""unq_users_username"""
+        ];
+    }
+
+    function dropForeignKey() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function basicIndex() {
+        return [
+            "CREATE TABLE ""users"" (""published_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+            "CREATE INDEX ""idx_users_published_date"" ON ""users"" (""published_date"")"
+        ];
+    }
+
+    function compositeIndex() {
+        return [
+            "CREATE TABLE ""users"" (""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL)",
+            "CREATE INDEX ""idx_users_first_name_last_name"" ON ""users"" (""first_name"", ""last_name"")"
+        ];
+    }
+
+    function overrideIndexName() {
+        return [
+            "CREATE TABLE ""users"" (""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL)",
+            "CREATE INDEX ""index_full_name"" ON ""users"" (""first_name"", ""last_name"")"
+        ];
+    }
+
+    function compositePrimaryKey() {
+        return [
+            "CREATE TABLE ""users"" (""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL, PRIMARY KEY (""first_name"", ""last_name""))"
+        ];
+    }
+    function overridePrimaryKeyIndexName() {
+        return [
+            "CREATE TABLE ""users"" (""first_name"" TEXT NOT NULL, ""last_name"" TEXT NOT NULL, PRIMARY KEY (""first_name"", ""last_name""))"
+        ];
+    }
+
+    function columnForeignKey() {
+        return [
+            "CREATE TABLE ""posts"" (""author_id"" INTEGER NOT NULL, FOREIGN KEY (""author_id"") REFERENCES ""users"" (""id"") ON UPDATE NO ACTION ON DELETE NO ACTION)"
+        ];
+    }
+
+    function tableForeignKey() {
+        return [
+            "CREATE TABLE ""posts"" (""author_id"" INTEGER NOT NULL, FOREIGN KEY (""author_id"") REFERENCES ""users"" (""id"") ON UPDATE NO ACTION ON DELETE NO ACTION)"
+        ];
+    }
+
+    function overrideColumnForeignKeyIndexName() {
+        return [
+            "CREATE TABLE ""posts"" (""author_id"" INTEGER NOT NULL, FOREIGN KEY (""author_id"") REFERENCES ""users"" (""id"") ON UPDATE NO ACTION ON DELETE NO ACTION)"
+        ];
+    }
+
+    function overrideTableForeignKeyIndexName() {
+        return [
+            "CREATE TABLE ""posts"" (""author_id"" INTEGER NOT NULL, FOREIGN KEY (""author_id"") REFERENCES ""users"" (""id"") ON UPDATE NO ACTION ON DELETE NO ACTION)"
+        ];
+    }
+
+    function renameTable() {
+        return [ "ALTER TABLE ""workers"" RENAME TO ""employees""" ];
+    }
+
+    function renameColumn() {
+        return [ "ALTER TABLE ""users"" RENAME COLUMN ""name"" TO ""username""" ];
+    }
+
+    function renameMultipleColumns() {
+        return [
+            "ALTER TABLE ""users"" RENAME COLUMN ""name"" TO ""username""",
+            "ALTER TABLE ""users"" RENAME COLUMN ""purchase_date"" TO ""purchased_at"""
+        ];
+    }
+
+    function modifyColumn() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function modifyMultipleColumns() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function addColumn() {
+        return [ "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL'))" ];
+    }
+
+    function addMultiple() {
+        return [
+            "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL'))",
+            "ALTER TABLE ""users"" ADD COLUMN ""is_active"" BOOLEAN NOT NULL"
+        ];
+    }
+
+    function dropTable() {
+        return [ "DROP TABLE ""users""" ];
+    }
+
+    function dropIfExists() {
+        return [ "DROP TABLE IF EXISTS ""users""" ];
+    }
+
+    function dropColumn() {
+        return [ "ALTER TABLE ""users"" DROP COLUMN ""username""" ];
+    }
+
+    function dropColumnWithColumn() {
+        return [ "ALTER TABLE ""users"" DROP COLUMN ""username""" ];
+    }
+
+    function dropsMultipleColumns() {
+        return [ "ALTER TABLE ""users"" DROP COLUMN ""username""", "ALTER TABLE ""users"" DROP COLUMN ""password""" ];
+    }
+
+    function dropColumnWithConstraint() {
+        return [ "ALTER TABLE ""users"" DROP COLUMN ""someFlag""" ];
+    }
+
+    function createView() {
+        return [ "CREATE VIEW ""active_users"" AS SELECT * FROM ""users"" WHERE ""active"" = ?" ];
+    }
+
+    function alterView() {
+        return [
+            "DROP VIEW ""active_users""",
+            "CREATE VIEW ""active_users"" AS SELECT * FROM ""users"" WHERE ""active"" = ?"
+        ];
+    }
+
+    function dropView() {
+        return [ "DROP VIEW ""active_users""" ];
+    }
+
+
+
+    private function getBuilder( mockGrammar ) {
+        var utils = getMockBox().createMock( "qb.models.Query.QueryUtils" );
+        arguments.mockGrammar = isNull( arguments.mockGrammar ) ? getMockBox()
+            .createMock( "qb.models.Grammars.SQLiteGrammar" )
+            .init( utils ) : arguments.mockGrammar;
+        var builder = getMockBox().createMock( "qb.models.Schema.SchemaBuilder" ).init( arguments.mockGrammar );
+        variables.mockGrammar = arguments.mockGrammar;
+        return builder;
+    }
+
+}

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -443,6 +443,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return { exception: "UnsupportedOperation" };
     }
 
+    function dropIndexFromName() {
+        return [ "DROP INDEX ""idx_username""" ];
+    }
+
+    function dropIndexFromIndex() {
+        return [ "DROP INDEX ""idx_users_username""" ];
+    }
+
     function basicIndex() {
         return [
             "CREATE TABLE ""users"" (""published_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -409,6 +409,14 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "ALTER TABLE [users] DROP CONSTRAINT [fk_posts_author_id]" ];
     }
 
+    function dropIndexFromName() {
+        return [ "DROP INDEX [users].[idx_username]" ];
+    }
+
+    function dropIndexFromIndex() {
+        return [ "DROP INDEX [users].[idx_users_username]" ];
+    }
+
     function basicIndex() {
         return [
             "CREATE TABLE [users] ([published_date] DATETIME2 NOT NULL, INDEX [idx_users_published_date] ([published_date]))"

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -104,6 +104,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE [employees] ([salary] FLOAT(2) NOT NULL)" ];
     }
 
+    function guid() {
+        return [ "CREATE TABLE [users] ([id] uniqueidentifier NOT NULL)" ];
+    }
+
     function increments() {
         return [ "CREATE TABLE [users] ([id] INTEGER NOT NULL IDENTITY, CONSTRAINT [pk_users_id] PRIMARY KEY ([id]))" ];
     }
@@ -315,7 +319,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uuid() {
-        return [ "CREATE TABLE [users] ([id] uniqueidentifier NOT NULL)" ];
+        return [ "CREATE TABLE [users] ([id] NCHAR(35) NOT NULL)" ];
     }
 
     function comment() {


### PR DESCRIPTION
## Breaking Changes

### Dropped support for Adobe ColdFusion 2016

Adobe has ended support for ACF 2016, and so must we.

### SchemaBuilder's `uuid` split into [`guid()`](https://github.com/v/9.0.0/schema-builder/columns#guid) and [`uuid()`](https://github.com/v/9.0.0/schema-builder/columns#uuid)

CFML's `uuid` does not match other languages; it's one character shorter. Because of this, the value from `createUUID()` cannot be used in some database column types like SQL Server's `uniqueidentifier`. This made for some confusion in SchemaBuilder since it wasn't clear if uuid meant CFML's definition or the wider world's definition.

So, the types have been split, following Lucee's pattern, into [`uuid`](https://github.com/v/9.0.0/schema-builder/columns#uuid) (matching CFML's [createUUID()](https://cfdocs.org/createuuid)) and [`guid`](https://github.com/v/9.0.0/schema-builder/columns#guid) (matching Java's UUID or [createGUID()](https://cfdocs.org/createguid) on Lucee).

### Returning all rows from [paginate](https://github.com/v/9.0.0/query-builder/executing-queries/retrieving-results#paginate) when maxRows is  0 or lower

Popular grid frameworks like Quasar and Datatables use values of 0 or -1 to return all rows from a query. This is now supported in qb. Previously, it generated an invalid query (`SELECT * FROM users LIMIT 0 OFFSET 0`).

This behavior can be customized by providing a callback to the shouldMaxRowsOverrideToAll setting or init argument. For instance, to revert to the previous behavior you would set the function as follows:

```cfc
moduleSettings = {
    "qb": {
        "shouldMaxRowsOverrideToAll": function( maxRows ) {
            return false;
        }
    }
};
```

### [`autoDeriveNumericType`](https://github.com/v/9.0.0/query-builder/building-queries/parameters-and-bindings#numeric-sql-type) is now the default

Introduced in [8.10.0](https://github.com/v/9.0.0/whats-new#8.10.0), this feature uses separate SQL types for integers and decimals to increase performance in certain database grammars.  This feature is now the default, but the previous behavior can be enabled by setting `autoDeriveNumericType` to `false`.

> Note: the option to revert to the old behavior will be removed in the next major version.

### [`strictDateDetection`](https://github.com/v/9.0.0/query-builder/building-queries/parameters-and-bindings#strict-date-detection) is now the default

Introduced in [8.1.0](https://github.com/v/9.0.0/whats-new#8.1.0), this feature only returns a SQL type of `CF_SQL_TIMESTAMP` if the param is a date object, not just a string that looks like a date.  This helps avoid situations where some strings were incorrectly interpreted as dates.  For many, the migration path is straightforward — calls to [`now()`](https://cfdocs.org/now) are already date objects as well as any function that operates on a date.  If you need to parse a string as a date, the [`parseDateTime`](https://cfdocs.org/parsedatetime) built-in function can accomplish that.

> Note: the option to revert to the old behavior _may_ be removed in the next major version.

## New Features and Improvements

### SQLite Grammar Support

Thanks to [Jason Steinhouer](https://github.com/jsteinshouer), qb now supports SQLite for both QueryBuilder and SchemaBuilder.  You can use it in your apps by specifying SQLiteGrammar@qb as the default grammar.

### [sqlCommenter Support](https://github.com/v/9.0.0/query-builder/debugging/sqlcommenter)

sqlCommenter is a [specification by Google](https://google.github.io/sqlcommenter/) for adding contextual information as a comment at the end of a SQL statement.  This can give insights into your application, especially when diagnosing slow queries. Examples of the information you can append to your queries are route, handler, action, version, and others, as well as the ability to add your own, such as `loggedInUser` and more.

### [sumRaw](https://github.com/v/9.0.0/query-builder/executing-queries/aggregates#sumraw) helper function

There's a new shortcut method to return `qb.sum( qb.raw( expression ) )`. You're welcome. 😉

### Dedicated [dropIndex](https://github.com/v/9.0.0/schema-builder/alter#dropindex) method

Some grammars, like SQL Server, do not treat simple indexes as constraints.  For this reason, we've added a [`dropIndex`](https://github.com/v/9.0.0/schema-builder/alter#dropindex) method alongside the existing [`dropConstraint`](https://github.com/v/9.0.0/schema-builder/alter#dropconstraint).

### [columnList](https://github.com/v/9.0.0/query-builder/executing-queries/aggregates#columnlist) helper method

[`columnList`](https://github.com/v/9.0.0/query-builder/executing-queries/aggregates#columnlist) will return either an array of column names for the configured table or the query that is generated by `cfdbinfo` for the configured table.  Especially useful when working with dynamically generated grids.

## Bug Fixes
- Correctly compile `insertUsing` statements that use Common Table Expressions (CTEs).
- Update announceInterception calls for ColdBox 7. (Thank you, [Michael Born](https://github.com/michaelborn).)
- Fixed `insertUsing` not placing Common Table Expressions (CTEs) in the correct order.
- Added the missing keyword in the Postgres [`upsert`](https://github.com/v/9.0.0/query-builder/executing-queries/inserts-updates-deletes#upsert) syntax.
- Don't add `DISTINCT` when doing a `COUNT(*)`.
- Support aggregates for unioned queries.