### PR TITLE
support {cross,outer} apply in SQLServerGrammar

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -278,8 +278,7 @@ component displayname="Grammar" accessors="true" singleton {
                 var table = wrapTable( join.getTable() );
                 // ("outer" | "cross") "apply" ( <raw> | <some-table-def> )
                 joinsArray.append( "#uCase( join.getType() )# #table#" );
-            }
-            else {
+            } else {
                 var conditions = compileWheres( join, join.getWheres() );
                 var table = wrapTable( join.getTable() );
                 joinsArray.append( "#uCase( join.getType() )# JOIN #table# #conditions#" );
@@ -1750,4 +1749,5 @@ component displayname="Grammar" accessors="true" singleton {
             detail = "crossOrOuterApply"
         );
     }
+
 }

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -274,9 +274,16 @@ component displayname="Grammar" accessors="true" singleton {
     private string function compileJoins( required QueryBuilder query, required array joins ) {
         var joinsArray = [];
         for ( var join in arguments.joins ) {
-            var conditions = compileWheres( join, join.getWheres() );
-            var table = wrapTable( join.getTable() );
-            joinsArray.append( "#uCase( join.getType() )# JOIN #table# #conditions#" );
+            if ( join.getType() == "cross apply" || join.getType() == "outer apply" ) {
+                var table = wrapTable( join.getTable() );
+                // ("outer" | "cross") "apply" ( <raw> | <some-table-def> )
+                joinsArray.append( "#uCase( join.getType() )# #table#" );
+            }
+            else {
+                var conditions = compileWheres( join, join.getWheres() );
+                var table = wrapTable( join.getTable() );
+                joinsArray.append( "#uCase( join.getType() )# JOIN #table# #conditions#" );
+            }
         }
 
         return arrayToList( joinsArray, " " );
@@ -1736,4 +1743,11 @@ component displayname="Grammar" accessors="true" singleton {
         return "";
     }
 
+    function crossOrOuterApply() {
+        throw(
+            type = "OperationNotSupported",
+            message = "This database grammar does not support this operation",
+            detail = "crossOrOuterApply"
+        );
+    }
 }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -680,4 +680,5 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         // no-op; existince of this function is enough to override the default implementation of
         // "always throw OperationNotSupported"
     }
+
 }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -676,4 +676,8 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return "TINYINT";
     }
 
+    function crossOrOuterApply() {
+        // no-op; existince of this function is enough to override the default implementation of
+        // "always throw OperationNotSupported"
+    }
 }

--- a/models/Query/JoinClause.cfc
+++ b/models/Query/JoinClause.cfc
@@ -30,7 +30,7 @@ component displayname="JoinClause" accessors="true" extends="qb.models.Query.Que
         "right",
         "right outer",
         "outer apply",
-        "cross apply",
+        "cross apply"
     ];
 
     /**

--- a/models/Query/JoinClause.cfc
+++ b/models/Query/JoinClause.cfc
@@ -28,7 +28,9 @@ component displayname="JoinClause" accessors="true" extends="qb.models.Query.Que
         "left",
         "left outer",
         "right",
-        "right outer"
+        "right outer",
+        "outer apply",
+        "cross apply",
     ];
 
     /**
@@ -114,6 +116,14 @@ component displayname="JoinClause" accessors="true" extends="qb.models.Query.Que
      */
     public boolean function isJoin() {
         return true;
+    }
+
+    public JoinClause function crossOrOuterApply() {
+        // default impl of `crossOrOuterApply` throws "OperationNotSupported";
+        // A concrete grammar impl may override and NOT throw, to indicate that this *is* supported.
+        parentQuery.getGrammar().crossOrOuterApply();
+        // ok, didn't throw. No work to do.
+        return this;
     }
 
 }

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -1019,8 +1019,8 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     private function outerOrCrossApply( required string name, required string type, required tableLikeSource ) {
-        if ( type != "outer apply" && type != "cross apply") {
-            throw(message="`type` must be 'outer apply' or 'cross apply'")
+        if ( type != "outer apply" && type != "cross apply" ) {
+            throw( message = "`type` must be 'outer apply' or 'cross apply'" )
         }
 
         if ( isClosure( arguments.tableLikeSource ) || isCustomFunction( arguments.tableLikeSource ) ) {
@@ -1034,11 +1034,13 @@ component displayname="QueryBuilder" accessors="true" {
             if ( tableLikeSource.getBindings().len() > 0 ) {
                 // an expression is not a QueryBuilder, and cannot be passed to `mergeBindings`,
                 // so we don't support this.
-                throw(type="OperationNotSupported", message="Raw expressions containing bindings are not supported in {cross,outer}apply table sources.");
+                throw(
+                    type = "OperationNotSupported",
+                    message = "Raw expressions containing bindings are not supported in {cross,outer}apply table sources."
+                );
             }
-            var table = raw(tableLikeSource.getSql() & " " & getGrammar().wrapTable( name ) );
-        }
-        else {
+            var table = raw( tableLikeSource.getSql() & " " & getGrammar().wrapTable( name ) );
+        } else {
             var table = raw( getGrammar().wrapTable( "(#arguments.tableLikeSource.toSQL()#) #arguments.name#" ) );
             mergeBindings( arguments.tableLikeSource );
         }
@@ -1051,19 +1053,11 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     public function outerApply( required string name, required any tableDef ) {
-        return outerOrCrossApply(
-            name = name,
-            type = "outer apply",
-            tableLikeSource = tableDef
-        );
+        return outerOrCrossApply( name = name, type = "outer apply", tableLikeSource = tableDef );
     }
 
     public function crossApply( required string name, required any tableDef ) {
-        return outerOrCrossApply(
-            name = name,
-            type = "cross apply",
-            tableLikeSource = tableDef
-        );
+        return outerOrCrossApply( name = name, type = "cross apply", tableLikeSource = tableDef );
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -1042,7 +1042,8 @@ component displayname="QueryBuilder" accessors="true" {
 
         return join(
             table = table,
-            type = type
+            type = type,
+            first = "" // null OK on lucee, "" for adobe
         );
     }
 

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -1036,7 +1036,7 @@ component displayname="QueryBuilder" accessors="true" {
                 // so we don't support this.
                 throw(type="OperationNotSupported", message="Raw expressions containing bindings are not supported in {cross,outer}apply table sources.");
             }
-            var table = tableLikeSource
+            var table = raw(tableLikeSource.getSql() & " " & getGrammar().wrapTable( name ) );
         }
         else {
             var table = raw( getGrammar().wrapTable( "(#arguments.tableLikeSource.toSQL()#) #arguments.name#" ) );

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -1031,12 +1031,15 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         if ( variables.utils.isExpression( tableLikeSource ) ) {
+            if ( tableLikeSource.getBindings().len() > 0 ) {
+                // an expression is not a QueryBuilder, and cannot be passed to `mergeBindings`,
+                // so we don't support this.
+                throw(type="OperationNotSupported", message="Raw expressions containing bindings are not supported in {cross,outer}apply table sources.");
+            }
             var table = tableLikeSource
-            // raw expression has no bindings, right ... ?
         }
         else {
             var table = raw( getGrammar().wrapTable( "(#arguments.tableLikeSource.toSQL()#) #arguments.name#" ) );
-            // merge bindings
             mergeBindings( arguments.tableLikeSource );
         }
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1306,6 +1306,50 @@ component extends="testbox.system.BaseSpec" {
                                 .where( "A.C", "=", "C" );
                         }, joinSubBindings() );
                     } );
+
+                    it( "can cross apply", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users as u" )
+                                .crossApply( "childCount", function( qb ) {
+                                    qb.selectRaw( "count(*) c" )
+                                        .from( "children" )
+                                        .whereColumn( "children.parentID", "=", "users.ID" )
+                                } )
+                                .select( ["u.ID", "childCount.c"] )
+                                .where( "childCount.c", ">", 4 )
+                        }, crossApply() );
+                    } );
+
+                    it( "can outer apply", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users as u" )
+                                .outerApply( "childCount", function( qb ) {
+                                    qb.selectRaw( "count(*) c" )
+                                        .from( "children" )
+                                        .whereColumn( "children.parentID", "=", "users.ID" )
+                                } )
+                                .select( ["u.ID", "childCount.c"] )
+                                .where( "childCount.c", ">", 4 )
+                        }, outerApply() );
+                    } );
+
+                    it( "can cross apply some raw expression", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users as u" )
+                                .crossApply( "childCount", builder.raw( "dbo.someUDF(u) x" ) )
+                        }, crossApplySomeRawExpression() );
+                    } );
+
+                    it( "can outer apply some raw expression", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users as u" )
+                                .outerApply( "childCount", builder.raw( "dbo.someUDF(u) x" ) )
+                        }, outerApplySomeRawExpression() );
+                    } );
                 } );
 
                 describe( "group bys", function() {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1341,7 +1341,7 @@ component extends="testbox.system.BaseSpec" {
                         testCase( function( builder ) {
                             builder
                                 .from( "users as u" )
-                                .crossApply( "childCount", builder.raw( "dbo.someUDF(u) x" ) )
+                                .crossApply( "x", builder.raw( "dbo.someUDF(u)" ) )
                         }, crossApplySomeRawExpression() );
                     } );
 
@@ -1349,7 +1349,7 @@ component extends="testbox.system.BaseSpec" {
                         testCase( function( builder ) {
                             builder
                                 .from( "users as u" )
-                                .outerApply( "childCount", builder.raw( "dbo.someUDF(u) x" ) )
+                                .outerApply( "x", builder.raw( "dbo.someUDF(u)" ) )
                         }, outerApplySomeRawExpression() );
                     } );
 
@@ -1357,7 +1357,7 @@ component extends="testbox.system.BaseSpec" {
                         testCase( function( builder ) {
                             builder
                                 .from( "users as u" )
-                                .outerApply( "childCount", builder.raw( "dbo.someUDF( ? ) x", [ 42 ] ) )
+                                .outerApply( "x", builder.raw( "dbo.someUDF( ? )", [ 42 ] ) )
                         }, rejectCrossApplyUsingRawExpressionHavingBindings() );
                     } );
                 } );

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1315,9 +1315,10 @@ component extends="testbox.system.BaseSpec" {
                                     qb.selectRaw( "count(*) c" )
                                         .from( "children" )
                                         .whereColumn( "children.parentID", "=", "users.ID" )
+                                        .where( "children.someCol", "=", 0 )
                                 } )
                                 .select( ["u.ID", "childCount.c"] )
-                                .where( "childCount.c", ">", 4 )
+                                .where( "childCount.c", ">", 1 )
                         }, crossApply() );
                     } );
 
@@ -1329,9 +1330,10 @@ component extends="testbox.system.BaseSpec" {
                                     qb.selectRaw( "count(*) c" )
                                         .from( "children" )
                                         .whereColumn( "children.parentID", "=", "users.ID" )
+                                        .where( "children.someCol", "=", 0 )
                                 } )
                                 .select( ["u.ID", "childCount.c"] )
-                                .where( "childCount.c", ">", 4 )
+                                .where( "childCount.c", ">", 1 )
                         }, outerApply() );
                     } );
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1350,6 +1350,14 @@ component extends="testbox.system.BaseSpec" {
                                 .outerApply( "childCount", builder.raw( "dbo.someUDF(u) x" ) )
                         }, outerApplySomeRawExpression() );
                     } );
+
+                    it( "rejects a crossApply against a raw expression having bindings", function() {
+                        testCase( function( builder ) {
+                            builder
+                                .from( "users as u" )
+                                .outerApply( "childCount", builder.raw( "dbo.someUDF( ? ) x", [ 42 ] ) )
+                        }, rejectCrossApplyUsingRawExpressionHavingBindings() );
+                    } );
                 } );
 
                 describe( "group bys", function() {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1317,7 +1317,7 @@ component extends="testbox.system.BaseSpec" {
                                         .whereColumn( "children.parentID", "=", "users.ID" )
                                         .where( "children.someCol", "=", 0 )
                                 } )
-                                .select( ["u.ID", "childCount.c"] )
+                                .select( [ "u.ID", "childCount.c" ] )
                                 .where( "childCount.c", ">", 1 )
                         }, crossApply() );
                     } );
@@ -1332,32 +1332,26 @@ component extends="testbox.system.BaseSpec" {
                                         .whereColumn( "children.parentID", "=", "users.ID" )
                                         .where( "children.someCol", "=", 0 )
                                 } )
-                                .select( ["u.ID", "childCount.c"] )
+                                .select( [ "u.ID", "childCount.c" ] )
                                 .where( "childCount.c", ">", 1 )
                         }, outerApply() );
                     } );
 
                     it( "can cross apply some raw expression", function() {
                         testCase( function( builder ) {
-                            builder
-                                .from( "users as u" )
-                                .crossApply( "x", builder.raw( "dbo.someUDF(u)" ) )
+                            builder.from( "users as u" ).crossApply( "x", builder.raw( "dbo.someUDF(u)" ) )
                         }, crossApplySomeRawExpression() );
                     } );
 
                     it( "can outer apply some raw expression", function() {
                         testCase( function( builder ) {
-                            builder
-                                .from( "users as u" )
-                                .outerApply( "x", builder.raw( "dbo.someUDF(u)" ) )
+                            builder.from( "users as u" ).outerApply( "x", builder.raw( "dbo.someUDF(u)" ) )
                         }, outerApplySomeRawExpression() );
                     } );
 
                     it( "rejects a crossApply against a raw expression having bindings", function() {
                         testCase( function( builder ) {
-                            builder
-                                .from( "users as u" )
-                                .outerApply( "x", builder.raw( "dbo.someUDF( ? )", [ 42 ] ) )
+                            builder.from( "users as u" ).outerApply( "x", builder.raw( "dbo.someUDF( ? )", [ 42 ] ) )
                         }, rejectCrossApplyUsingRawExpressionHavingBindings() );
                     } );
                 } );

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -1001,32 +1001,23 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function crossApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function crossApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function rejectCrossApplyUsingRawExpressionHavingBindings() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
+
 }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -1023,4 +1023,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
             exception: "OperationNotSupported"
         }
     }
+
+    function rejectCrossApplyUsingRawExpressionHavingBindings() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -1000,4 +1000,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return builder;
     }
 
+    function crossApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function crossApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -1017,32 +1017,23 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function crossApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function crossApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function rejectCrossApplyUsingRawExpressionHavingBindings() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
+
 }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -1039,4 +1039,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
             exception: "OperationNotSupported"
         }
     }
+
+    function rejectCrossApplyUsingRawExpressionHavingBindings() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -1016,4 +1016,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return builder;
     }
 
+    function crossApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function crossApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -1031,4 +1031,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return builder;
     }
 
+    function crossApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function crossApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -1032,32 +1032,23 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function crossApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function crossApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function rejectCrossApplyUsingRawExpressionHavingBindings() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
+
 }

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -1054,4 +1054,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
             exception: "OperationNotSupported"
         }
     }
+
+    function rejectCrossApplyUsingRawExpressionHavingBindings() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1032,32 +1032,23 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function crossApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApply() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function crossApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     function outerApplySomeRawExpression() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
-    
+
     function rejectCrossApplyUsingRawExpressionHavingBindings() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
+
 }

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1054,4 +1054,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
             exception: "OperationNotSupported"
         }
     }
+    
+    function rejectCrossApplyUsingRawExpressionHavingBindings() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1031,4 +1031,27 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function crossApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApply() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function crossApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
+    function outerApplySomeRawExpression() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
 }

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1032,9 +1032,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function rejectCrossApplyUsingRawExpressionHavingBindings() {
-        return {
-            exception: "OperationNotSupported"
-        }
+        return { exception: "OperationNotSupported" }
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1024,11 +1024,11 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
     }
 
     function crossApplySomeRawExpression() {
-        return "SELECT * FROM [users] AS [u] CROSS APPLY dbo.someUDF(u) x";
+        return "SELECT * FROM [users] AS [u] CROSS APPLY dbo.someUDF(u) [x]";
     }
 
     function outerApplySomeRawExpression() {
-        return "SELECT * FROM [users] AS [u] OUTER APPLY dbo.someUDF(u) x";
+        return "SELECT * FROM [users] AS [u] OUTER APPLY dbo.someUDF(u) [x]";
     }
 
     function rejectCrossApplyUsingRawExpressionHavingBindings() {

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1011,15 +1011,15 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function crossApply() {
         return {
-            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] CROSS APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID]) AS [childCount] WHERE [childCount].[c] > ?",
-            bindings: [4]
+            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] CROSS APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID] AND [children].[someCol] = ?) AS [childCount] WHERE [childCount].[c] > ?",
+            bindings: [ 0, 1 ]
         }
     }
 
     function outerApply() {
         return {
-            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] OUTER APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID]) AS [childCount] WHERE [childCount].[c] > ?",
-            bindings: [4]
+            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] OUTER APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID] AND [children].[someCol] = ?) AS [childCount] WHERE [childCount].[c] > ?",
+            bindings: [ 0, 1 ]
         }
     }
 

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1009,6 +1009,28 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM [otherTable]";
     }
 
+    function crossApply() {
+        return {
+            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] CROSS APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID]) AS [childCount] WHERE [childCount].[c] > ?",
+            bindings: [4]
+        }
+    }
+
+    function outerApply() {
+        return {
+            sql: "SELECT [u].[ID], [childCount].[c] FROM [users] AS [u] OUTER APPLY (SELECT count(*) c FROM [children] WHERE [children].[parentID] = [users].[ID]) AS [childCount] WHERE [childCount].[c] > ?",
+            bindings: [4]
+        }
+    }
+
+    function crossApplySomeRawExpression() {
+        return "SELECT * FROM [users] AS [u] CROSS APPLY dbo.someUDF(u) x";
+    }
+
+    function outerApplySomeRawExpression() {
+        return "SELECT * FROM [users] AS [u] OUTER APPLY dbo.someUDF(u) x";
+    }
+
     private function getBuilder() {
         variables.utils = getMockBox().createMock( "qb.models.Query.QueryUtils" ).init();
         variables.grammar = getMockBox().createMock( "qb.models.Grammars.SqlServerGrammar" ).init( variables.utils );

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1031,6 +1031,12 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return "SELECT * FROM [users] AS [u] OUTER APPLY dbo.someUDF(u) x";
     }
 
+    function rejectCrossApplyUsingRawExpressionHavingBindings() {
+        return {
+            exception: "OperationNotSupported"
+        }
+    }
+
     private function getBuilder() {
         variables.utils = getMockBox().createMock( "qb.models.Query.QueryUtils" ).init();
         variables.grammar = getMockBox().createMock( "qb.models.Grammars.SqlServerGrammar" ).init( variables.utils );


### PR DESCRIPTION
This adds basic support for cross and outer apply.

It is enabled only for SQLServerGrammar, all other grammars will throw `OperationNotSupported`. A quick look at oracle docs indicates this might be trivial to enable for the Oracle grammar, while other databases might not be able to support it (postgres would need to compile as a lateral join which would probably have to be a separate construct). I only have an SqlServer instance to test against.

Usage is like:
```
qb
  .from("foo")
  .crossApply(
    "barView",
    (qb) => qb
      .from("bar")
      .whereColumn("foo.col", "=", "bar.col")
      .select("count(*) c")
  )
  .select( ["foo.id", "barView.c"])
  .where("barView.c", ">", 10)

// compiles to

select foo.id, barView.c
from foo
cross apply (
  select count(*) c
  from bar
  where foo.col = bar.col
) as barView
where barview.c > 10
```

One way to view the capability here is to consider it as defining an inline view.

Or another way to look at is this gives you the ability to combine the "best of both worlds" of a correlated subquery and join against a subquery -- that is, a correlated subquery can see the outer query but cannot be used in a where clause, and a join against a subquery can be used in a where clause but not see the outer query. Sometimes it's nice to have both.
