### PR TITLE
Use CHAR for GUID and UUID types in MySQL

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1464,7 +1464,7 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     function typeGUID( column ) {
-        return typeChar( column, 36 );
+        return typeChar( column );
     }
 
     function typeInteger( column ) {
@@ -1497,7 +1497,7 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     function typeUUID( column ) {
-        return typeChar( column, 35 );
+        return typeChar( column );
     }
 
     function typeLineString( column ) {

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -231,6 +231,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "CHAR(#column.getLength()#)";
     }
 
+    function typeUUID( column ) {
+        return typeGUID( column );
+    }
+
     function typeLineString( column ) {
         return "LINESTRING";
     }

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -227,6 +227,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "NCHAR(#column.getLength()#)";
     }
 
+    function typeGUID( column ) {
+        return "CHAR(#column.getLength()#)";
+    }
+
     function typeLineString( column ) {
         return "LINESTRING";
     }

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -109,7 +109,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function guid() {
-        return [ "CREATE TABLE `users` (`id` NCHAR(36) NOT NULL)" ];
+        return [ "CREATE TABLE `users` (`id` CHAR(36) NOT NULL)" ];
     }
 
     function increments() {
@@ -361,7 +361,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function nullable() {
-        return [ "CREATE TABLE `users` (`id` NCHAR(36))" ];
+        return [ "CREATE TABLE `users` (`id` CHAR(36))" ];
     }
 
     function unsigned() {

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -333,7 +333,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function uuid() {
-        return [ "CREATE TABLE `users` (`id` NCHAR(35) NOT NULL)" ];
+        return [ "CREATE TABLE `users` (`id` CHAR(35) NOT NULL)" ];
     }
 
     function comment() {


### PR DESCRIPTION
Use CHAR for GUID and UUID types in MySQL
