### PR TITLE
fix(queryUtils): Resolve `getUtils()` missing method error

### DIFF
--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -136,7 +136,7 @@ component singleton displayname="QueryUtils" accessors="true" {
                 }
 
                 if ( inline ) {
-                    return getUtils().castAsSqlType(
+                    return castAsSqlType(
                         value = thisBinding.null ? javacast( "null", "" ) : thisBinding.value,
                         sqltype = thisBinding.cfsqltype
                     );


### PR DESCRIPTION
This resolves a `Error: No matching function [GETUTILS] found` error thrown when running `replaceBindings()` with `inline = true`.