### PR TITLE
fix(OracleGrammar): Better support for Oracle Grammar in cfmigrations

### DIFF
--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -5,6 +5,9 @@ component accessors="true" {
     property name="table";
     property name="commands";
 
+    property name="queryOptions";
+    property name="defaultSchema";
+
     property name="columns";
     property name="dropColumns";
     property name="indexes";
@@ -12,9 +15,16 @@ component accessors="true" {
     property name="creating" default="false";
     property name="ifExists" default="false";
 
-    public Blueprint function init( required SchemaBuilder schemaBuilder, required any grammar ) {
-        setSchemaBuilder( schemaBuilder );
-        setGrammar( grammar );
+    public Blueprint function init(
+        required SchemaBuilder schemaBuilder,
+        required any grammar,
+        struct queryOptions = {},
+        string defaultSchema = ""
+    ) {
+        setSchemaBuilder( arguments.schemaBuilder );
+        setGrammar( arguments.grammar );
+        setQueryOptions( arguments.queryOptions );
+        setDefaultSchema( arguments.defaultSchema );
 
         setColumns( [] );
         setDropColumns( [] );

--- a/models/Schema/SchemaBuilder.cfc
+++ b/models/Schema/SchemaBuilder.cfc
@@ -76,7 +76,12 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "create" );
         blueprint.setCreating( true );
         blueprint.setTable( arguments.table );
@@ -110,7 +115,12 @@ component accessors="true" {
         var query = new models.Query.QueryBuilder( getGrammar() );
         arguments.callback( query );
 
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "createView", { query: query } );
         blueprint.setCreating( true );
         blueprint.setTable( arguments.view );
@@ -145,7 +155,12 @@ component accessors="true" {
         var query = new models.Query.QueryBuilder( getGrammar() );
         arguments.callback( query );
 
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "alterView", { query: query } );
         blueprint.setCreating( true );
         blueprint.setTable( arguments.view );
@@ -172,7 +187,12 @@ component accessors="true" {
 
     public Blueprint function dropView( required string view, struct options = {}, boolean execute = true ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "dropView" );
         blueprint.setTable( arguments.view );
 
@@ -207,7 +227,12 @@ component accessors="true" {
      */
     public Blueprint function drop( required string table, struct options = {}, boolean execute = true ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "drop" );
         blueprint.setTable( arguments.table );
         if ( arguments.execute ) {
@@ -240,7 +265,12 @@ component accessors="true" {
      */
     public Blueprint function dropIfExists( required string table, struct options = {}, boolean execute = true ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.addCommand( "drop" );
         blueprint.setTable( arguments.table );
         blueprint.setIfExists( true );
@@ -281,7 +311,12 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.setTable( arguments.table );
         arguments.callback( blueprint );
         if ( arguments.execute ) {
@@ -320,7 +355,12 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var blueprint = new Blueprint( this, getGrammar() );
+        var blueprint = new Blueprint(
+            this,
+            getGrammar(),
+            arguments.options,
+            getDefaultSchema()
+        );
         blueprint.setTable( arguments.from );
         blueprint.addCommand( "renameTable", { to: arguments.to } );
         if ( arguments.execute ) {
@@ -380,7 +420,7 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var args = [ arguments.name ];
+        var args = [ listLast( arguments.name, "." ) ];
         if ( arguments.schema != "" ) {
             arrayAppend( args, arguments.schema );
         }
@@ -417,7 +457,7 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
-        var args = [ arguments.table, arguments.column ];
+        var args = [ listLast( arguments.table, "." ), arguments.column ];
         if ( arguments.schema != "" ) {
             arrayAppend( args, arguments.schema );
         }
@@ -446,7 +486,11 @@ component accessors="true" {
      *
      * @returns The array of executed statements.
      */
-    public array function dropAllObjects( struct options = {}, boolean execute = true, string schema = variables.defaultSchema ) {
+    public array function dropAllObjects(
+        struct options = {},
+        boolean execute = true,
+        string schema = variables.defaultSchema
+    ) {
         structAppend( arguments.options, variables.defaultOptions, false );
         var statements = getGrammar().compileDropAllObjects( arguments.options, arguments.schema );
         if ( arguments.execute ) {

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -1,5 +1,42 @@
 component extends="tests.resources.AbstractSchemaBuilderSpec" {
 
+    function run() {
+        super.run();
+
+        describe( "Oracle Grammar-specific tests", function() {
+            it( "attempts to drop sequences and triggers when dropping a table", () => {
+                try {
+                    var schema = getBuilder();
+                    variables.mockGrammar.$( "hasSequence", true );
+                    variables.mockGrammar.$( "hasTrigger", true );
+                    var statements = schema.drop( "users", {}, false );
+                    if ( !isSimpleValue( statements ) ) {
+                        statements = statements.toSql();
+                    }
+                    if ( !isArray( statements ) ) {
+                        statements = [ statements ];
+                    }
+                    expect( statements ).toBeArray();
+                    var expected = [
+                        "DROP TABLE ""USERS""",
+                        "DROP SEQUENCE ""SEQ_USERS""",
+                        "DROP TRIGGER ""TRG_USERS"""
+                    ];
+                    expect( statements ).toHaveLength( arrayLen( expected ) );
+                    for ( var i = 1; i <= expected.len(); i++ ) {
+                        expect( statements[ i ] ).toBeWithCase( expected[ i ] );
+                    }
+                } catch ( any e ) {
+                    if ( !isSimpleValue( expected ) && !isArray( expected ) && structKeyExists( expected, "exception" ) ) {
+                        expect( e.type ).toBe( expected.exception );
+                        return;
+                    }
+                    rethrow;
+                }
+            } );
+        } );
+    }
+
     function emptyTable() {
         return [ "CREATE TABLE ""USERS"" ()" ];
     }
@@ -12,7 +49,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, ""USERNAME"" VARCHAR2(255) NOT NULL, ""FIRST_NAME"" VARCHAR2(255) NOT NULL, ""LAST_NAME"" VARCHAR2(255) NOT NULL, ""PASSWORD"" VARCHAR2(100) NOT NULL, ""COUNTRY_ID"" NUMBER(10, 0) NOT NULL, ""CREATED_DATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL, ""MODIFIED_DATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""), CONSTRAINT ""FK_USERS_COUNTRY_ID"" FOREIGN KEY (""COUNTRY_ID"") REFERENCES ""COUNTRIES"" (""ID"") ON DELETE CASCADE)",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -20,7 +57,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(19, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -122,7 +159,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -154,7 +191,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(7, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -226,7 +263,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(5, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -290,7 +327,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [
             "CREATE TABLE ""USERS"" (""ID"" NUMBER(3, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
             "CREATE SEQUENCE ""SEQ_USERS""",
-            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (new.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO :new.""ID"" FROM dual; END"
+            "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
     }
 
@@ -595,20 +632,20 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function hasTable() {
-        return [ "SELECT 1 FROM ""DBA_TABLES"" WHERE ""TABLE_NAME"" = ?" ];
+        return [ "SELECT 1 FROM ""ALL_TABLES"" WHERE ""TABLE_NAME"" = ?" ];
     }
 
     function hasTableInSchema() {
-        return [ "SELECT 1 FROM ""DBA_TABLES"" WHERE ""TABLE_NAME"" = ? AND ""OWNER"" = ?" ];
+        return [ "SELECT 1 FROM ""ALL_TABLES"" WHERE ""TABLE_NAME"" = ? AND ""OWNER"" = ?" ];
     }
 
     function hasColumn() {
-        return [ "SELECT 1 FROM ""DBA_TAB_COLUMNS"" WHERE ""TABLE_NAME"" = ? AND ""COLUMN_NAME"" = ?" ];
+        return [ "SELECT 1 FROM ""ALL_TAB_COLUMNS"" WHERE ""TABLE_NAME"" = ? AND ""COLUMN_NAME"" = ?" ];
     }
 
     function hasColumnInSchema() {
         return [
-            "SELECT 1 FROM ""DBA_TAB_COLUMNS"" WHERE ""TABLE_NAME"" = ? AND ""COLUMN_NAME"" = ? AND ""OWNER"" = ?"
+            "SELECT 1 FROM ""ALL_TAB_COLUMNS"" WHERE ""TABLE_NAME"" = ? AND ""COLUMN_NAME"" = ? AND ""OWNER"" = ?"
         ];
     }
 
@@ -634,6 +671,8 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
             .init( utils ) : arguments.mockGrammar;
         var builder = getMockBox().createMock( "qb.models.Schema.SchemaBuilder" ).init( arguments.mockGrammar );
         variables.mockGrammar = arguments.mockGrammar;
+        variables.mockGrammar.$( "hasSequence", false );
+        variables.mockGrammar.$( "hasTrigger", false );
         return builder;
     }
 


### PR DESCRIPTION
1. Fix trigger creation by escaping colons (`:`).
2. Try to drop associated sequences and triggers when dropping a table.
3. Better support for creating a table in a different schema by only checking for the last identifier as the table name in `hasTable` and `hasColumn`.