### PR TITLE
Add MariaDB to AutoDiscover

### DIFF
--- a/models/Grammars/AutoDiscover.cfc
+++ b/models/Grammars/AutoDiscover.cfc
@@ -7,7 +7,7 @@ component singleton {
         cfdbinfo( type = "Version", name = "local.dbInfo" );
 
         switch ( dbInfo.DATABASE_PRODUCTNAME ) {
-            case "MySQL":
+            case "MySQL": case "MariaDB":
                 return wirebox.getInstance( "MySQLGrammar@qb" );
             case "PostgreSQL":
                 return wirebox.getInstance( "PostgresGrammar@qb" );

--- a/models/Grammars/AutoDiscover.cfc
+++ b/models/Grammars/AutoDiscover.cfc
@@ -7,7 +7,8 @@ component singleton {
         cfdbinfo( type = "Version", name = "local.dbInfo" );
 
         switch ( dbInfo.DATABASE_PRODUCTNAME ) {
-            case "MySQL": case "MariaDB":
+            case "MySQL":
+            case "MariaDB":
                 return wirebox.getInstance( "MySQLGrammar@qb" );
             case "PostgreSQL":
                 return wirebox.getInstance( "PostgresGrammar@qb" );


### PR DESCRIPTION
Although MariaDB is a drop-in replacement for MySQL, it has its own JDBC driver which is also available as a [Lucee extension](https://forgebox.io/view/F2FA5DB2-0C27-499C-B1171D2D812FDAF9). Using that driver will result in ```DATABASE_PRODUCTNAME = 'MariaDB'```, which in turn causes qb to fall back to its BaseGrammar that is not working with MariaDB.

Hence the suggestion to let the AutoDiscover feature recognize datasources using the MariaDB driver and treat them like MySQL databases.
