### PR TITLE
Feature/options datasource set grammar

### DIFF
--- a/models/Grammars/AutoDiscover.cfc
+++ b/models/Grammars/AutoDiscover.cfc
@@ -3,8 +3,13 @@ component singleton {
     property name="wirebox" inject="wirebox";
     property name="grammar";
 
-    function autoDiscoverGrammar() {
-        cfdbinfo( type = "Version", name = "local.dbInfo" );
+    function autoDiscoverGrammar(any datasource = "") {
+        if(arguments.datasource.len()){
+            cfdbinfo( type = "Version", name = "local.dbInfo", datasource=arguments.datasource );
+        } else {
+            cfdbinfo( type = "Version", name = "local.dbInfo" );
+        }
+        
 
         switch ( dbInfo.DATABASE_PRODUCTNAME ) {
             case "MySQL":
@@ -24,7 +29,7 @@ component singleton {
 
     function onMissingMethod( missingMethodName, missingMethodArguments ) {
         if ( !structKeyExists( variables, "grammar" ) ) {
-            variables.grammar = autoDiscoverGrammar();
+            variables.grammar = autoDiscoverGrammar(arguments.missingMethodArguments[2].keyExists("datasource") ? arguments.missingMethodArguments[2].datasource : "");
         }
         return invoke( variables.grammar, missingMethodName, missingMethodArguments );
     }

--- a/models/Grammars/AutoDiscover.cfc
+++ b/models/Grammars/AutoDiscover.cfc
@@ -3,13 +3,13 @@ component singleton {
     property name="wirebox" inject="wirebox";
     property name="grammar";
 
-    function autoDiscoverGrammar(any datasource = "") {
-        if(arguments.datasource.len()){
-            cfdbinfo( type = "Version", name = "local.dbInfo", datasource=arguments.datasource );
+    function autoDiscoverGrammar( any datasource = "" ) {
+        if ( arguments.datasource.len() ) {
+            cfdbinfo( type = "Version", name = "local.dbInfo", datasource = arguments.datasource );
         } else {
             cfdbinfo( type = "Version", name = "local.dbInfo" );
         }
-        
+
 
         switch ( dbInfo.DATABASE_PRODUCTNAME ) {
             case "MySQL":
@@ -29,7 +29,9 @@ component singleton {
 
     function onMissingMethod( missingMethodName, missingMethodArguments ) {
         if ( !structKeyExists( variables, "grammar" ) ) {
-            variables.grammar = autoDiscoverGrammar(arguments.missingMethodArguments[2].keyExists("datasource") ? arguments.missingMethodArguments[2].datasource : "");
+            variables.grammar = autoDiscoverGrammar(
+                arguments.missingMethodArguments[ 2 ].keyExists( "datasource" ) ? arguments.missingMethodArguments[ 2 ].datasource : ""
+            );
         }
         return invoke( variables.grammar, missingMethodName, missingMethodArguments );
     }

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3282,7 +3282,7 @@ component displayname="QueryBuilder" accessors="true" {
         if ( !isNull( arguments.columns ) ) {
             select( arguments.columns );
         }
-        var result = run( sql = this.toSql(options=arguments.options), options = arguments.options );
+        var result = run( sql = this.toSql( options = arguments.options ), options = arguments.options );
         select( originalColumns );
         return isNull( result ) ? javacast( "null", "" ) : result;
     }
@@ -3705,7 +3705,7 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @return string
      */
-    public string function toSQL( any showBindings = false, struct options={} ) {
+    public string function toSQL( any showBindings = false, struct options = {} ) {
         var sql = grammar.compileSelect( this, options );
 
         if ( isBoolean( arguments.showBindings ) && arguments.showBindings == false ) {

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3282,7 +3282,7 @@ component displayname="QueryBuilder" accessors="true" {
         if ( !isNull( arguments.columns ) ) {
             select( arguments.columns );
         }
-        var result = run( sql = this.toSql(), options = arguments.options );
+        var result = run( sql = this.toSql(options=arguments.options), options = arguments.options );
         select( originalColumns );
         return isNull( result ) ? javacast( "null", "" ) : result;
     }
@@ -3705,8 +3705,8 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @return string
      */
-    public string function toSQL( any showBindings = false ) {
-        var sql = grammar.compileSelect( this );
+    public string function toSQL( any showBindings = false, struct options={} ) {
+        var sql = grammar.compileSelect( this, options );
 
         if ( isBoolean( arguments.showBindings ) && arguments.showBindings == false ) {
             return sql;


### PR DESCRIPTION
Added passing the options struct to the toSQL() method in get() so AutoDiscover can use the datasource key to determine the correct grammar.

In AutoDiscover.cfc, also added a ( rather inelegant ) if / else where if a datasource was passed in, it used that to perform the cfdbinfo and if there wasn't one, it ran it without submitting one at all in order to trigger using this.datasource. I tried submitting a javacast("null") if there wasn't a datasource submitted but it didn't seem to like it. 