### PR TITLE
Performance improvement for large recordsets

### DIFF
--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -332,18 +332,18 @@ component singleton displayname="QueryUtils" accessors="true" {
             rethrow;
         }
 
-        return queryReduce(
-            arguments.q,
-            function( results, row ) {
-                var rowData = structNew( "ordered" );
-                for ( var column in queryColumns ) {
-                    rowData[ column ] = row[ column ];
-                }
-                results.append( rowData );
-                return results;
-            },
-            []
-        );
+        var results = [];
+        if ( arguments.q.recordCount > 0 ) {
+            arrayResize( results, arguments.q.recordCount );
+        }
+        for ( var row in arguments.q ) {
+            var rowData = structNew( "ordered" );
+            for ( var column in queryColumns ) {
+                rowData[ column ] = row[ column ];
+            }
+            results[ arguments.q.currentRow ] = rowData;
+        }
+        return results;
     }
 
     /**

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -323,6 +323,10 @@ component singleton displayname="QueryUtils" accessors="true" {
      * @return array
      */
     public array function queryToArrayOfStructs( required any q ) {
+        if ( arguments.q.recordCount == 0 ) {
+            return [];
+        }
+
         try {
             var queryColumns = getMetadata( arguments.q ).map( function( item ) {
                 return item.name;
@@ -333,9 +337,7 @@ component singleton displayname="QueryUtils" accessors="true" {
         }
 
         var results = [];
-        if ( arguments.q.recordCount > 0 ) {
-            arrayResize( results, arguments.q.recordCount );
-        }
+        arrayResize( results, arguments.q.recordCount );
         for ( var row in arguments.q ) {
             var rowData = structNew( "ordered" );
             for ( var column in queryColumns ) {

--- a/tests/specs/Query/Abstract/PaginationSpec.cfc
+++ b/tests/specs/Query/Abstract/PaginationSpec.cfc
@@ -130,6 +130,25 @@ component extends="testbox.system.BaseSpec" {
                 expect( results.results ).toBe( expectedResults );
             } );
 
+            it( "can handle empty datasets", function() {
+                var builder = getBuilder();
+                var expectedResults = [];
+                var expectedQuery = queryNew( "id", "integer", expectedResults );
+                builder.$( "count", 0 );
+                builder.$( "runQuery", expectedQuery );
+
+                var results = builder.from( "users" ).paginate( page = 1, maxRows = 0 );
+
+                expect( results.pagination ).toBe( {
+                    "maxRows": 0,
+                    "offset": 0,
+                    "page": 1,
+                    "totalPages": 0,
+                    "totalRecords": 0
+                } );
+                expect( results.results ).toBe( expectedResults );
+            } );
+
             it( "can provide a custom paginator shell", function() {
                 var builder = getBuilder();
                 builder.setPaginationCollector( {


### PR DESCRIPTION
Particularly noticeable on ACF which spends a lot of time resizing the array inside the QueryReduce

```
100% 59.950s coldfusion.runtime.QueryFunction.QueryReduce
...
43.8% 26.237s coldfusion.runtime.Variable.set
43.8% 26.237s coldfusion.runtime.ArrayUtil.copy
43.8% 26.237s coldfusion.runtime.ArrayUtil.addElement
43.8% 26.237s coldfusion.runtime.ArrayList.add
43.8% 26.237s coldfusion.runtime.ArrayList.grow
43.8% 26.237s coldfusion.runtime.ArrayList.grow
43.8% 26.237s coldfusion.runtime.ArrayList.copyOf
```

Rough example:
https://trycf.com/gist/32ca606bab55a41801b531b15eb02416/acf2018?theme=monokai