### PR TITLE
Fix serializeBindings() for array bindings

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1817,8 +1817,10 @@ component displayname="Grammar" accessors="true" singleton {
         return serializeJSON(
             arguments.bindings.map( function( binding ) {
                 var newBinding = duplicate( binding );
-                if ( isBinary( newBinding.value ) ) {
+                if ( isStruct( newBinding ) && isBinary( newBinding.value ) ) {
                     newBinding.value = toBase64( newBinding.value );
+                } else if ( isBinary( newBinding ) ) {
+                    newBinding = toBase64( newBinding );
                 }
                 return newBinding;
             } )


### PR DESCRIPTION
Resolves query logging on queries that use array bindings, such as the SqlServerGrammar's `getAllTableNames()` method:

https://github.com/coldbox-modules/qb/blob/main/models/Grammars/SqlServerGrammar.cfc#L544

See this stack trace.

https://pastebin.com/jgWFmdgj