### PR TITLE
added ability to specify precision for timestamp datatypes

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1643,7 +1643,7 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     function typeTimestamp( column ) {
-        return "TIMESTAMP";
+        return "TIMESTAMP#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1643,7 +1643,7 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     function typeTimestamp( column ) {
-        return "TIMESTAMP#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
+        return "TIMESTAMP#isNull( column.getPrecision() ) ? "" : "(#column.getPrecision()#)"#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -623,7 +623,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     }
 
     function typeTimestamp( column ) {
-        return "TIMESTAMP#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
+        return "TIMESTAMP#isNull( column.getPrecision() ) ? "" : "(#column.getPrecision()#)"#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -623,7 +623,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     }
 
     function typeTimestamp( column ) {
-        return "DATE";
+        return "TIMESTAMP#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -694,7 +694,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
     }
 
     function typeTimestamp( column ) {
-        return "DATETIME2";
+        return "DATETIME2#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -694,7 +694,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
     }
 
     function typeTimestamp( column ) {
-        return "DATETIME2#isNull( column.getPrecision() ) ? '' : '(#column.getPrecision()#)'#";
+        return "DATETIME2#isNull( column.getPrecision() ) ? "" : "(#column.getPrecision()#)"#";
     }
 
     function typeTimestampTz( column ) {

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -272,7 +272,7 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
-    public Column function timestamp( required string name ) {
+    public Column function timestamp( required string name, numeric precision ) {
         arguments.type = "timestamp";
         return appendColumn( argumentCollection = arguments );
     }

--- a/models/Schema/Column.cfc
+++ b/models/Schema/Column.cfc
@@ -199,8 +199,8 @@ component accessors="true" {
      *
      * @returns Column
      */
-    public Column function withCurrent() {
-        setDefault( "CURRENT_TIMESTAMP" );
+    public Column function withCurrent( numeric precision ) {
+        setDefault( "CURRENT_TIMESTAMP#isNull( arguments.precision ) ? '' : '(#arguments.precision#)'#" );
         return this;
     }
 

--- a/models/Schema/Column.cfc
+++ b/models/Schema/Column.cfc
@@ -200,7 +200,7 @@ component accessors="true" {
      * @returns Column
      */
     public Column function withCurrent( numeric precision ) {
-        setDefault( "CURRENT_TIMESTAMP#isNull( arguments.precision ) ? '' : '(#arguments.precision#)'#" );
+        setDefault( "CURRENT_TIMESTAMP#isNull( arguments.precision ) ? "" : "(#arguments.precision#)"#" );
         return this;
     }
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -798,8 +798,8 @@ component extends="testbox.system.BaseSpec" {
                             {},
                             false
                         );
-                    }, timestampPrecision(6) );
-                } );                
+                    }, timestampPrecision( 6 ) );
+                } );
 
                 it( "timestampWithNullable", function() {
                     testCase( function( schema ) {

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -788,6 +788,19 @@ component extends="testbox.system.BaseSpec" {
                     }, timestamp() );
                 } );
 
+                it( "timestampPrecision", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "posts",
+                            function( table ) {
+                                table.timestamp( "posted_date", 6 );
+                            },
+                            {},
+                            false
+                        );
+                    }, timestampPrecision(6) );
+                } );                
+
                 it( "timestampWithNullable", function() {
                     testCase( function( schema ) {
                         return schema.create(

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -258,6 +258,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `posts` (`posted_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
     }
 
+    function timestampPrecision() {
+        return [ "CREATE TABLE `posts` (`posted_date` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
+    }
+
     function timestampWithNullable() {
         return [ "CREATE TABLE `posts` (`posted_date` TIMESTAMP NULL DEFAULT NULL)" ];
     }

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -47,7 +47,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
 
     function complicatedTable() {
         return [
-            "CREATE TABLE ""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, ""USERNAME"" VARCHAR2(255) NOT NULL, ""FIRST_NAME"" VARCHAR2(255) NOT NULL, ""LAST_NAME"" VARCHAR2(255) NOT NULL, ""PASSWORD"" VARCHAR2(100) NOT NULL, ""COUNTRY_ID"" NUMBER(10, 0) NOT NULL, ""CREATED_DATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL, ""MODIFIED_DATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""), CONSTRAINT ""FK_USERS_COUNTRY_ID"" FOREIGN KEY (""COUNTRY_ID"") REFERENCES ""COUNTRIES"" (""ID"") ON DELETE CASCADE)",
+            "CREATE TABLE ""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, ""USERNAME"" VARCHAR2(255) NOT NULL, ""FIRST_NAME"" VARCHAR2(255) NOT NULL, ""LAST_NAME"" VARCHAR2(255) NOT NULL, ""PASSWORD"" VARCHAR2(100) NOT NULL, ""COUNTRY_ID"" NUMBER(10, 0) NOT NULL, ""CREATED_DATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, ""MODIFIED_DATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""), CONSTRAINT ""FK_USERS_COUNTRY_ID"" FOREIGN KEY (""COUNTRY_ID"") REFERENCES ""COUNTRIES"" (""ID"") ON DELETE CASCADE)",
             "CREATE SEQUENCE ""SEQ_USERS""",
             "CREATE OR REPLACE TRIGGER ""TRG_USERS"" BEFORE INSERT ON ""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
         ];
@@ -106,7 +106,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function datetime() {
-        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" DATE NOT NULL)" ];
+        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" TIMESTAMP NOT NULL)" ];
     }
 
     function datetimeTz() {
@@ -230,7 +230,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function nullableTimestamps() {
-        return [ "CREATE TABLE ""POSTS"" (""CREATEDDATE"" DATE, ""MODIFIEDDATE"" DATE)" ];
+        return [ "CREATE TABLE ""POSTS"" (""CREATEDDATE"" TIMESTAMP, ""MODIFIEDDATE"" TIMESTAMP)" ];
     }
 
     function point() {
@@ -242,7 +242,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function softDeletes() {
-        return [ "CREATE TABLE ""POSTS"" (""DELETEDDATE"" DATE)" ];
+        return [ "CREATE TABLE ""POSTS"" (""DELETEDDATE"" TIMESTAMP)" ];
     }
 
     function softDeletesTz() {
@@ -296,7 +296,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function time() {
-        return [ "CREATE TABLE ""RECURRING_TASKS"" (""FIRE_TIME"" DATE NOT NULL)" ];
+        return [ "CREATE TABLE ""RECURRING_TASKS"" (""FIRE_TIME"" TIMESTAMP NOT NULL)" ];
     }
 
     function timeTz() {
@@ -304,12 +304,16 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function timestamp() {
-        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" DATE NOT NULL)" ];
+        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" TIMESTAMP NOT NULL)" ];
+    }
+
+    function timestampPrecision() {
+        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" TIMESTAMP(6) NOT NULL)" ];
     }
 
     function timestamps() {
         return [
-            "CREATE TABLE ""POSTS"" (""CREATEDDATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL, ""MODIFIEDDATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL)"
+            "CREATE TABLE ""POSTS"" (""CREATEDDATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, ""MODIFIEDDATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL)"
         ];
     }
 
@@ -407,11 +411,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function timestampWithCurrent() {
-        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" DATE DEFAULT CURRENT_TIMESTAMP NOT NULL)" ];
+        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL)" ];
     }
 
     function timestampWithNullable() {
-        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" DATE)" ];
+        return [ "CREATE TABLE ""POSTS"" (""POSTED_DATE"" TIMESTAMP)" ];
     }
 
     function nullable() {
@@ -497,7 +501,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
 
     function basicIndex() {
         return [
-            "CREATE TABLE ""USERS"" (""PUBLISHED_DATE"" DATE NOT NULL)",
+            "CREATE TABLE ""USERS"" (""PUBLISHED_DATE"" TIMESTAMP NOT NULL)",
             "CREATE INDEX ""IDX_USERS_PUBLISHED_DATE"" ON ""USERS"" (""PUBLISHED_DATE"")"
         ];
     }
@@ -586,7 +590,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     function modifyMultipleColumns() {
         return [
             "ALTER TABLE ""USERS"" MODIFY (""NAME"" CLOB NOT NULL)",
-            "ALTER TABLE ""USERS"" MODIFY (""PURCHASED_DATE"" DATE)"
+            "ALTER TABLE ""USERS"" MODIFY (""PURCHASED_DATE"" TIMESTAMP)"
         ];
     }
 
@@ -610,7 +614,7 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
             "ALTER TABLE ""USERS"" DROP COLUMN ""IS_ACTIVE""",
             "ALTER TABLE ""USERS"" ADD ""TSHIRT_SIZE"" VARCHAR2(255) NOT NULL",
             "ALTER TABLE ""USERS"" RENAME COLUMN ""NAME"" TO ""USERNAME""",
-            "ALTER TABLE ""USERS"" MODIFY (""PURCHASE_DATE"" DATE)",
+            "ALTER TABLE ""USERS"" MODIFY (""PURCHASE_DATE"" TIMESTAMP)",
             "ALTER TABLE ""USERS"" ADD CONSTRAINT ""UNQ_USERS_USERNAME"" UNIQUE (""USERNAME"")",
             "ALTER TABLE ""USERS"" ADD CONSTRAINT ""UNQ_USERS_EMAIL"" UNIQUE (""EMAIL"")",
             "ALTER TABLE ""USERS"" DROP CONSTRAINT ""IDX_USERS_CREATED_DATE""",

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -253,6 +253,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""posts"" (""posted_date"" TIMESTAMP NOT NULL)" ];
     }
 
+    function timestampPrecision() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TIMESTAMP(6) NOT NULL)" ];
+    }
+
+
     function timestamps() {
         return [
             "CREATE TABLE ""posts"" (""createdDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, ""modifiedDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)"

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -285,6 +285,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
     }
 
+    function timestampPrecision() {
+        return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)" ];
+    }
+
     function timestampWithNullable() {
         return [ "CREATE TABLE ""posts"" (""posted_date"" TEXT)" ];
     }

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -250,6 +250,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE [posts] ([posted_date] DATETIME2 NOT NULL)" ];
     }
 
+    function timestampPrecision() {
+        return [ "CREATE TABLE [posts] ([posted_date] DATETIME2(6) NOT NULL)" ];
+    }
+
     function timestampTz() {
         return [ "CREATE TABLE [posts] ([posted_date] DATETIMEOFFSET NOT NULL)" ];
     }


### PR DESCRIPTION
Added ability to specify timestamp precision for TIMESTAMP datatypes.

The `timestamp()` schema function can now accept an option precision argument which will append `(x)` where x is the precision value. If the precision argument is omitted the parenthesis  will not be appended to the datatype

Fix related to quick pr https://github.com/coldbox-modules/quick/pull/250 