### PR TITLE
Fixes Error When Raw Expressions are in Upsert Return Columns

### DIFF
--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -412,7 +412,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         }
         var updateStatement = updateList == "" ? "" : " WHEN MATCHED THEN UPDATE SET #updateList#";
 
-        var deleteStatement = arguments.deleteUnmatched ? " WHEN NOT MATCHED BY SOURCE DELETE" : "";
+        var deleteStatement = arguments.deleteUnmatched ? " WHEN NOT MATCHED BY SOURCE THEN DELETE" : "";
 
         var returningColumns = arguments.qb
             .getReturning()

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -415,17 +415,17 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         var deleteStatement = arguments.deleteUnmatched ? " WHEN NOT MATCHED BY SOURCE DELETE" : "";
 
         var returningColumns = arguments.qb
-		    .getReturning()
-		    .map( function( column ) {
-			    if ( getUtils().isExpression( column ) ) {
-			    	return trim( column.getSQL() );
-			    }
-			    if ( listLen( column, "." ) > 1 ) {
-			    	return column;
-			    }
-			    return "INSERTED." & wrapColumn( column );
-		    } )
-		    .toList( ", " );
+            .getReturning()
+            .map( function( column ) {
+                if ( getUtils().isExpression( column ) ) {
+                    return trim( column.getSQL() );
+                }
+                if ( listLen( column, "." ) > 1 ) {
+                    return column;
+                }
+                return "INSERTED." & wrapColumn( column );
+            } )
+            .toList( ", " );
 
         var returningClause = returningColumns != "" ? " OUTPUT #returningColumns#" : "";
 

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -93,7 +93,7 @@ component singleton displayname="QueryUtils" accessors="true" {
             return arguments.value.getBindings();
         }
 
-        var binding = "";
+        var binding = {};
         if ( isStruct( value ) ) {
             if ( structKeyExists( value, "isExpression" ) && value.isExpression == true ) {
                 return value;
@@ -103,7 +103,10 @@ component singleton displayname="QueryUtils" accessors="true" {
             binding = { value: normalizeSqlValue( value ) };
         }
 
-        structAppend( binding, { cfsqltype: inferSqlType( binding.value ), list: false, null: false }, false );
+        if ( !structKeyExists( binding, "cfsqltype" ) ) {
+            binding.cfsqltype = inferSqlType( binding.value );
+        }
+        structAppend( binding, { list: false, null: false }, false );
 
         if ( variables.autoAddScale && isFloatingPoint( binding ) ) {
             param binding.scale = calculateNumberOfDecimalDigits( binding );

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -915,7 +915,7 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
 
     function upsertWithDelete() {
         return {
-            sql: "MERGE [users] AS [qb_target] USING (SELECT [username], [active], [createdDate], [modifiedDate] FROM [activeDirectoryUsers] WHERE [active] = ?) AS [qb_src] ON [qb_target].[username] = [qb_src].[username] WHEN MATCHED THEN UPDATE SET [active] = [qb_src].[active], [modifiedDate] = [qb_src].[modifiedDate] WHEN NOT MATCHED BY TARGET THEN INSERT ([username], [active], [createdDate], [modifiedDate]) VALUES ([username], [active], [createdDate], [modifiedDate]) WHEN NOT MATCHED BY SOURCE DELETE;",
+            sql: "MERGE [users] AS [qb_target] USING (SELECT [username], [active], [createdDate], [modifiedDate] FROM [activeDirectoryUsers] WHERE [active] = ?) AS [qb_src] ON [qb_target].[username] = [qb_src].[username] WHEN MATCHED THEN UPDATE SET [active] = [qb_src].[active], [modifiedDate] = [qb_src].[modifiedDate] WHEN NOT MATCHED BY TARGET THEN INSERT ([username], [active], [createdDate], [modifiedDate]) VALUES ([username], [active], [createdDate], [modifiedDate]) WHEN NOT MATCHED BY SOURCE THEN DELETE;",
             bindings: [ 1 ]
         };
     }


### PR DESCRIPTION
The `returningColumns` in the `compileUpsert` method did not account for expressions. Example

```
.returningRaw( [
     "DELETED.ID AS deleted",
     "INSERTED.ID AS upserted"
] )
```