### PR TITLE
Fix Query Utils convertEmptyStringsToNull constructor option

### DIFF
--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -33,6 +33,7 @@ component singleton displayname="QueryUtils" accessors="true" {
         string decimalSqlType = "DECIMAL",
         any log
     ) {
+        variables.convertEmptyStringsToNull = arguments.convertEmptyStringsToNull;
         variables.integerSqlType = arguments.integerSqlType;
         variables.decimalSqlType = arguments.decimalSqlType;
         if ( !isNull( arguments.log ) ) {


### PR DESCRIPTION
This pull request fixes the `convertEmptyStringsToNull` param not being persisted to the component's variables scope.

Fixes #297 