### PR TITLE
Failing tests for dynamic column operator

### DIFF
--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -93,6 +93,12 @@ component extends="testbox.system.BaseSpec" {
                         }, wrapColumnsAndAliases() );
                     } );
 
+                    it( "parses operators like > in dynamic whereColumns", function() {
+                        testCase( function( builder ) {
+                            builder.select( "ID").from( "users").whereID(">", 1 )
+                        }, parseOperatorsWithDynamicWhere() )
+                    } );
+
                     it( "selects raw values correctly", function() {
                         testCase( function( builder ) {
                             builder.select( builder.raw( "substr( foo, 6 )" ) ).from( "users" );

--- a/tests/specs/Query/DerbyQueryBuilderSpec.cfc
+++ b/tests/specs/Query/DerbyQueryBuilderSpec.cfc
@@ -36,6 +36,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT ""users"".""foo"" FROM ""users"" WHERE ""users"".""foo"" = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT ""ID"" FROM ""users"" WHERE ""ID"" > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT ""u"".*, ""user_roles"".""roleid"", ""roles"".""rolecode"" FROM ""users"" AS ""u"" INNER JOIN ""user_roles"" ON ""user_roles"".""userid"" = ""u"".""userid"" LEFT JOIN ""roles"" ON ""user_roles"".""roleid"" = ""roles"".""roleid"" WHERE ""user_roles"".""roleid"" = (SELECT ""roleid"" FROM ""roles"" WHERE ""rolecode"" = ?)",

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -36,6 +36,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT `users`.`foo` FROM `users` WHERE `users`.`foo` = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT `ID` FROM `users` WHERE `ID` > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT `u`.*, `user_roles`.`roleid`, `roles`.`rolecode` FROM `users` AS `u` INNER JOIN `user_roles` ON `user_roles`.`userid` = `u`.`userid` LEFT JOIN `roles` ON `user_roles`.`roleid` = `roles`.`roleid` WHERE `user_roles`.`roleid` = (SELECT `roleid` FROM `roles` WHERE `rolecode` = ?)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -36,6 +36,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT ""USERS"".""FOO"" FROM ""USERS"" WHERE ""USERS"".""FOO"" = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT ""ID"" FROM ""users"" WHERE ""ID"" > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT ""U"".*, ""USER_ROLES"".""ROLEID"", ""ROLES"".""ROLECODE"" FROM ""USERS"" ""U"" INNER JOIN ""USER_ROLES"" ON ""USER_ROLES"".""USERID"" = ""U"".""USERID"" LEFT JOIN ""ROLES"" ON ""USER_ROLES"".""ROLEID"" = ""ROLES"".""ROLEID"" WHERE ""USER_ROLES"".""ROLEID"" = (SELECT ""ROLEID"" FROM ""ROLES"" WHERE ""ROLECODE"" = ?)",

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -36,6 +36,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT ""users"".""foo"" FROM ""users"" WHERE ""users"".""foo"" = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT ""ID"" FROM ""users"" WHERE ""ID"" > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT ""u"".*, ""user_roles"".""roleid"", ""roles"".""rolecode"" FROM ""users"" AS ""u"" INNER JOIN ""user_roles"" ON ""user_roles"".""userid"" = ""u"".""userid"" LEFT JOIN ""roles"" ON ""user_roles"".""roleid"" = ""roles"".""roleid"" WHERE ""user_roles"".""roleid"" = (SELECT ""roleid"" FROM ""roles"" WHERE ""rolecode"" = ?)",

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -43,6 +43,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT ""users"".""foo"" FROM ""users"" WHERE ""users"".""foo"" = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT ""ID"" FROM ""users"" WHERE ""ID"" > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT ""u"".*, ""user_roles"".""roleid"", ""roles"".""rolecode"" FROM ""users"" AS ""u"" INNER JOIN ""user_roles"" ON ""user_roles"".""userid"" = ""u"".""userid"" LEFT JOIN ""roles"" ON ""user_roles"".""roleid"" = ""roles"".""roleid"" WHERE ""user_roles"".""roleid"" = (SELECT ""roleid"" FROM ""roles"" WHERE ""rolecode"" = ?)",

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -36,6 +36,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { "sql": "SELECT [users].[foo] FROM [users] WHERE [users].[foo] = ?", "bindings": [ "bar" ] };
     }
 
+    function parseOperatorsWithDynamicWhere() {
+        return { "sql" : "SELECT [ID] FROM [users] WHERE [ID] > ?", "bindings": [ 1 ] }
+    }
+
     function parseColumnAliasInWhereSubselect() {
         return {
             "sql": "SELECT [u].*, [user_roles].[roleid], [roles].[rolecode] FROM [users] AS [u] INNER JOIN [user_roles] ON [user_roles].[userid] = [u].[userid] LEFT JOIN [roles] ON [user_roles].[roleid] = [roles].[roleid] WHERE [user_roles].[roleid] = (SELECT [roleid] FROM [roles] WHERE [rolecode] = ?)",


### PR DESCRIPTION
Adds test and each DB grammar for the following use case:

`builder.select( "foo" ).from( "bar" ).whereID( ">", 1 )`

This produces "=" rather than ">" in qb 13.0.2.