### PR TITLE
move "for" clause to last position

### DIFF
--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -13,7 +13,6 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         "aggregate",
         "columns",
         "tableName",
-        "forClause",
         "lockType",
         "joins",
         "wheres",
@@ -22,7 +21,8 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         "unions",
         "orders",
         "offsetValue",
-        "limitValue"
+        "limitValue",
+        "forClause"
     ];
 
 


### PR DESCRIPTION
I had run into a case where it was emitting invalid sql like
```
select foo
from bar
for json auto -- invalid position for this, needs to come last
join baz on 1=1
```

So this is intended to move the for clause into the last position after all the select/from/join/where