### PR TITLE
fix: add native JSON type support for SQL Server 2025

### DIFF
--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -852,11 +852,11 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
     }
 
     function typeJson( column ) {
-        return "NVARCHAR(MAX)";
+        return "JSON";
     }
 
     function typeJsonb( column ) {
-        return "NVARCHAR(MAX)";
+        return "JSON";
     }
 
     function typeLongText( column ) {

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -121,11 +121,11 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
     }
 
     function json() {
-        return [ "CREATE TABLE [users] ([personalizations] NVARCHAR(MAX) NOT NULL)" ];
+        return [ "CREATE TABLE [users] ([personalizations] JSON NOT NULL)" ];
     }
 
     function jsonb() {
-        return [ "CREATE TABLE [users] ([personalizations] NVARCHAR(MAX) NOT NULL)" ];
+        return [ "CREATE TABLE [users] ([personalizations] JSON NOT NULL)" ];
     }
 
     function lineString() {


### PR DESCRIPTION
SQL Server 2025 (v17.x) introduces a native JSON data type with binary-optimized storage and full JSON function support.

- typeJson() now returns 'JSON' instead of 'NVARCHAR(MAX)'
- typeJsonb() now returns 'JSON' instead of 'NVARCHAR(MAX)'
- Updated SqlServerSchemaBuilderSpec json/jsonb DDL expectations