### PR TITLE
fix(SchemaBuilder): allow timestamps in alter statements

### DIFF
--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -283,8 +283,14 @@ component accessors="true" {
     }
 
     public Blueprint function timestamps() {
-        appendColumn( name = "createdDate", type = "timestamp" ).withCurrent();
-        appendColumn( name = "modifiedDate", type = "timestamp" ).withCurrent();
+        var createdDate = appendColumn( name = "createdDate", type = "timestamp" ).withCurrent();
+        var modifiedDate = appendColumn( name = "modifiedDate", type = "timestamp" ).withCurrent();
+
+        if ( !getCreating() ) {
+            addColumn( createdDate );
+            addColumn( modifiedDate );
+        }
+
         return this;
     }
 

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -1647,6 +1647,19 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             describe( "adding columns", function() {
+                it( "can add timestamp columns", function() {
+                    testCase( function( schema ) {
+                        return schema.alter(
+                            "users",
+                            function( table ) {
+                                table.timestamps();
+                            },
+                            {},
+                            false
+                        );
+                    }, addTimestamps() );
+                } );
+
                 it( "can add a new column", function() {
                     testCase( function( schema ) {
                         return schema.alter(

--- a/tests/specs/Schema/DerbySchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/DerbySchemaBuilderSpec.cfc
@@ -548,6 +548,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE ""users"" ADD COLUMN ""createdDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+            "ALTER TABLE ""users"" ADD COLUMN ""modifiedDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ];
+    }
+
     function addMultiple() {
         return [
             "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" VARCHAR(255) NOT NULL",

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -541,6 +541,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "ALTER TABLE `users` ADD `tshirt_size` ENUM('S', 'M', 'L', 'XL', 'XXL') NOT NULL" ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE `users` ADD `createdDate` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+            "ALTER TABLE `users` ADD `modifiedDate` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ];
+    }
+
     function addMultiple() {
         return [
             "ALTER TABLE `users` ADD `tshirt_size` ENUM('S', 'M', 'L', 'XL', 'XXL') NOT NULL",

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -605,6 +605,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE ""USERS"" ADD ""CREATEDDATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL",
+            "ALTER TABLE ""USERS"" ADD ""MODIFIEDDATE"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL"
+        ];
+    }
+
     function addMultiple() {
         return [
             "ALTER TABLE ""USERS"" ADD ""TSHIRT_SIZE"" VARCHAR2(255) NOT NULL",

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -565,6 +565,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE ""users"" ADD COLUMN ""createdDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+            "ALTER TABLE ""users"" ADD COLUMN ""modifiedDate"" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ];
+    }
+
     function addMultiple() {
         return [
             "CREATE TYPE ""tshirt_size"" AS ENUM ('S', 'M', 'L', 'XL', 'XXL')",

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -556,6 +556,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE ""users"" ADD COLUMN ""createdDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP",
+            "ALTER TABLE ""users"" ADD COLUMN ""modifiedDate"" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ];
+    }
+
     function addMultiple() {
         return [
             "ALTER TABLE ""users"" ADD COLUMN ""tshirt_size"" TEXT NOT NULL CHECK (""tshirt_size"" IN ('S', 'M', 'L', 'XL', 'XXL'))",

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -535,6 +535,13 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         ];
     }
 
+    function addTimestamps() {
+        return [
+            "ALTER TABLE [users] ADD [createdDate] DATETIME2 NOT NULL CONSTRAINT [df_users_createdDate] DEFAULT CURRENT_TIMESTAMP",
+            "ALTER TABLE [users] ADD [modifiedDate] DATETIME2 NOT NULL CONSTRAINT [df_users_modifiedDate] DEFAULT CURRENT_TIMESTAMP"
+        ];
+    }
+
     function addMultiple() {
         return [
             "ALTER TABLE [users] ADD [tshirt_size] NVARCHAR(255) NOT NULL, CONSTRAINT [enum_users_tshirt_size] CHECK ([tshirt_size] IN ('S', 'M', 'L', 'XL', 'XXL'))",


### PR DESCRIPTION
## Summary

- queue both `createdDate` and `modifiedDate` columns when `timestamps()` is used in an alter callback
- preserve the existing create-table behavior
- cover generated alter SQL for all six supported schema grammars

## Root cause

`timestamps()` appended two columns and returned the blueprint. Unlike single-column helpers, it could not be passed to `addColumn()`, and an alter blueprint did not automatically queue either appended column. As a result, there was no supported way to add both timestamp columns with the shortcut.

## Validation

- reproduced first with a failing regression test: expected 2 alter statements, received 0
- schema suite: 836 passed
- full suite on Lucee 6.2.7.16: 2,586 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format:check`
- `git diff --check`

Fixes #310