### PR TITLE
ci: disable Lucee bleeding-edge checks

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,8 +15,6 @@ jobs:
         experimental: [ false ]
         fullNull: ["true", "false"]
         include:
-          - cfengine: "lucee@be"
-            experimental: true
           - cfengine: "adobe@be"
             experimental: true
           - cfengine: "boxlang@be"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,8 +23,6 @@ jobs:
         experimental: [ false ]
         fullNull: ["true", "false"]
         include:
-          - cfengine: "lucee@be"
-            experimental: true
           - cfengine: "adobe@be"
             experimental: true
           - cfengine: "boxlang@be"


### PR DESCRIPTION
## Summary

- remove `lucee@be` from the pull-request and branch-push test matrix
- remove `lucee@be` from the weekly cron test matrix
- retain stable Lucee 5 and 6 coverage and the existing Adobe/BoxLang bleeding-edge jobs

## Why

The current Lucee bleeding-edge release cannot load through CFConfig, so the server fails before qb tests can run. Disabling the job prevents recurring false-failure notifications until that toolchain is supported again.

## Validation

- parsed both workflow files as YAML
- confirmed no `lucee@be` entries remain under `.github/workflows`
- `git diff --check`