### PR TITLE
feat(QueryBuilder): validate duplicate select columns

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -12,6 +12,7 @@ component {
             "defaultReturnFormat": "array",
             "preventDuplicateJoins": false,
             "validateOperatorsAndCombinators": true,
+            "validateDuplicateSelectColumns": false,
             "validateQueryExecuteReturnType": false,
             "collectQueryLog": true,
             "convertEmptyStringsToNull": true,
@@ -71,6 +72,7 @@ component {
             .initArg( name = "returnFormatterRegistry", ref = "ReturnFormatterRegistry@qb" )
             .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
             .initArg( name = "validateOperatorsAndCombinators", value = settings.validateOperatorsAndCombinators )
+            .initArg( name = "validateDuplicateSelectColumns", value = settings.validateDuplicateSelectColumns )
             .initArg( name = "validateQueryExecuteReturnType", value = settings.validateQueryExecuteReturnType )
             .initArg( name = "collectQueryLog", value = settings.collectQueryLog )
             .initArg( name = "returnFormat", value = settings.defaultReturnFormat )

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ moduleSettings = {
 };
 ```
 
-The validation checks simple columns, explicit aliases, subselect aliases, and typed columns. Wildcards and raw expressions without explicit aliases are skipped because their output names cannot be known until the query executes.
+The validation checks the final selection when the query is compiled, including simple columns, explicit aliases, subselect aliases, and explicitly aliased typed columns. Wildcards and expressions without explicit aliases are skipped because their output names cannot be known until the query executes.
 
 ## Return Formatters
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ q = queryExecute(
 
 qb enables you to explore new ways of organizing your code by letting you pass around a query builder object that will compile down to the right SQL without you having to keep track of the order, whitespace, or other SQL gotchas!
 
+## Development Validation
+
+qb can detect statically identifiable duplicate select output names before they are silently collapsed by CFML query results. Enable this validation in development and leave it disabled in production:
+
+```cfc
+moduleSettings = {
+    "qb": {
+        "validateDuplicateSelectColumns": true
+    }
+};
+```
+
+The validation checks simple columns, explicit aliases, subselect aliases, and typed columns. Wildcards and raw expressions without explicit aliases are skipped because their output names cannot be known until the query executes.
+
 ## Return Formatters
 
 qb includes named return formatters for `array`, `query`, `none`, and `struct`. The `struct` formatter returns a struct of rows keyed by a selected column:

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -351,7 +351,7 @@ component displayname="QueryBuilder" accessors="true" {
         sqlCommenter = new qb.models.SQLCommenter.NullSQLCommenter(),
         shouldMaxRowsOverrideToAll,
         boolean collectQueryLog = true,
-        validateDuplicateSelectColumns = false
+        boolean validateDuplicateSelectColumns = false
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -489,7 +489,6 @@ component displayname="QueryBuilder" accessors="true" {
         if ( newColumns.isEmpty() ) {
             newColumns = [ { "type": "simple", "value": "*" } ];
         }
-        validateUniqueSelectColumns( newColumns );
         variables.columns = newColumns;
         return this;
     }
@@ -572,6 +571,10 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         if ( arguments.column.type == "simple" && find( "*", arguments.column.value ) ) {
+            return;
+        }
+
+        if ( arguments.column.type == "jsonPath" && !arguments.column.keyExists( "alias" ) ) {
             return;
         }
 
@@ -678,10 +681,7 @@ component displayname="QueryBuilder" accessors="true" {
             arguments.query = newQuery();
             callback( arguments.query );
         }
-        var newColumns = variables.columns.isEmpty() ? [] : arraySlice( variables.columns, 1 );
-        newColumns.append( { "type": "builder", "value": arguments.query, "alias": arguments.alias } );
-        validateUniqueSelectColumns( newColumns );
-        variables.columns = newColumns;
+        variables.columns.append( { "type": "builder", "value": arguments.query, "alias": arguments.alias } );
         addBindings( arguments.query.getBindings(), "select" );
         return this;
     }
@@ -715,7 +715,6 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         arrayAppend( selectedColumns, newColumns, true );
-        validateUniqueSelectColumns( selectedColumns );
         variables.columns = selectedColumns;
         return this;
     }
@@ -4866,6 +4865,9 @@ component displayname="QueryBuilder" accessors="true" {
      * @return string
      */
     public string function toSQL( any showBindings = false ) {
+        if ( getAggregate().isEmpty() ) {
+            validateUniqueSelectColumns( getColumns() );
+        }
         var sql = grammar.compileSelect( this );
 
         if ( isBoolean( arguments.showBindings ) && arguments.showBindings == false ) {

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -43,6 +43,13 @@ component displayname="QueryBuilder" accessors="true" {
     property name="validateOperatorsAndCombinators";
 
     /**
+     * If true, QB validates that selected columns have unique output names.
+     * This validation is recommended in development and should be disabled in production.
+     * @default false
+     */
+    property name="validateDuplicateSelectColumns";
+
+    /**
      * If true, QB throws when queryExecute returntype options are passed.
      * If false, QB strips those options so return formatters always receive a query.
      * @default false
@@ -306,6 +313,9 @@ component displayname="QueryBuilder" accessors="true" {
      * @validateOperatorsAndCombinators
      *                              Whether QB validates operators/combinators before storing clauses.
      *                              Default: true
+     * @validateDuplicateSelectColumns
+     *                              Whether QB validates selected columns have unique output names.
+     *                              Recommended in development and disabled in production. Default: false
      * @validateQueryExecuteReturnType
      *                              Whether QB throws when queryExecute returntype options are passed.
      *                              Default: false
@@ -340,13 +350,15 @@ component displayname="QueryBuilder" accessors="true" {
         defaultOptions = {},
         sqlCommenter = new qb.models.SQLCommenter.NullSQLCommenter(),
         shouldMaxRowsOverrideToAll,
-        boolean collectQueryLog = true
+        boolean collectQueryLog = true,
+        validateDuplicateSelectColumns = false
     ) {
         variables.grammar = arguments.grammar;
         variables.utils = arguments.utils;
 
         setPreventDuplicateJoins( arguments.preventDuplicateJoins );
         setValidateOperatorsAndCombinators( arguments.validateOperatorsAndCombinators );
+        setValidateDuplicateSelectColumns( arguments.validateDuplicateSelectColumns );
         setValidateQueryExecuteReturnType( arguments.validateQueryExecuteReturnType );
         if ( isNull( arguments.returnFormatterRegistry ) ) {
             arguments.returnFormatterRegistry = new qb.models.Query.ReturnFormatterRegistry( arguments.utils );
@@ -470,13 +482,15 @@ component displayname="QueryBuilder" accessors="true" {
      * @return qb.models.Query.QueryBuilder
      */
     public QueryBuilder function select( any columns = "*" ) {
-        variables.columns = normalizeToArray( arguments.columns )
+        var newColumns = normalizeToArray( arguments.columns )
             .map( ( column ) => applyColumnFormatter( column ) )
             .map( ( column ) => mapToColumnType( column ) );
 
-        if ( variables.columns.isEmpty() ) {
-            variables.columns = [ { "type": "simple", "value": "*" } ];
+        if ( newColumns.isEmpty() ) {
+            newColumns = [ { "type": "simple", "value": "*" } ];
         }
+        validateUniqueSelectColumns( newColumns );
+        variables.columns = newColumns;
         return this;
     }
 
@@ -504,6 +518,84 @@ component displayname="QueryBuilder" accessors="true" {
                 extendedinfo = serializeJSON( arguments.column )
             );
         }
+    }
+
+    /**
+     * Validates that all statically identifiable select output names are unique.
+     * Wildcards and raw expressions without explicit aliases are skipped because
+     * their output names cannot be determined without executing the query.
+     */
+    private void function validateUniqueSelectColumns( required array columns ) {
+        if ( !getValidateDuplicateSelectColumns() ) {
+            return;
+        }
+
+        var outputNames = {};
+        for ( var column in arguments.columns ) {
+            var outputName = getSelectOutputName( column );
+            if ( isNull( outputName ) ) {
+                continue;
+            }
+
+            var normalizedName = normalizeSelectOutputName( outputName );
+            if ( structKeyExists( outputNames, normalizedName ) ) {
+                throw(
+                    type = "DuplicateSelectColumn",
+                    message = "Multiple selected columns produce the output name [#outputName#].",
+                    detail = "Alias one of the columns to produce unique result keys."
+                );
+            }
+            outputNames[ normalizedName ] = true;
+        }
+    }
+
+    /**
+     * Returns a statically identifiable output name for a selected column.
+     */
+    private any function getSelectOutputName( required struct column ) {
+        if ( arguments.column.type == "builder" ) {
+            return arguments.column.alias;
+        }
+
+        if ( arguments.column.type == "raw" ) {
+            var rawSql = trim( arguments.column.value.getSQL() );
+            var aliasMatch = reFindNoCase(
+                "\s+AS\s+((?:`[^`]+`)|(?:\[[^\]]+\])|(?:""[^""]+"")|(?:[A-Za-z_][A-Za-z0-9_$]*))\s*$",
+                rawSql,
+                1,
+                true
+            );
+            if ( aliasMatch.pos.len() < 2 || aliasMatch.pos[ 1 ] == 0 ) {
+                return;
+            }
+            return mid( rawSql, aliasMatch.pos[ 2 ], aliasMatch.len[ 2 ] );
+        }
+
+        if ( arguments.column.type == "simple" && find( "*", arguments.column.value ) ) {
+            return;
+        }
+
+        if ( listFindNoCase( "simple,jsonPath", arguments.column.type ) ) {
+            return getGrammar().extractAlias( arguments.column );
+        }
+    }
+
+    /**
+     * Normalizes an output name for the case-insensitive keys used by CFML structs.
+     */
+    private string function normalizeSelectOutputName( required string outputName ) {
+        var normalizedName = trim( arguments.outputName );
+        if (
+            len( normalizedName ) >= 2 &&
+            (
+                ( left( normalizedName, 1 ) == "[" && right( normalizedName, 1 ) == "]" ) ||
+                ( left( normalizedName, 1 ) == "`" && right( normalizedName, 1 ) == "`" ) ||
+                ( left( normalizedName, 1 ) == """" && right( normalizedName, 1 ) == """" )
+            )
+        ) {
+            normalizedName = mid( normalizedName, 2, len( normalizedName ) - 2 );
+        }
+        return lCase( normalizedName );
     }
 
     /**
@@ -586,7 +678,10 @@ component displayname="QueryBuilder" accessors="true" {
             arguments.query = newQuery();
             callback( arguments.query );
         }
-        variables.columns.append( { "type": "builder", "value": arguments.query, "alias": arguments.alias } );
+        var newColumns = variables.columns.isEmpty() ? [] : arraySlice( variables.columns, 1 );
+        newColumns.append( { "type": "builder", "value": arguments.query, "alias": arguments.alias } );
+        validateUniqueSelectColumns( newColumns );
+        variables.columns = newColumns;
         addBindings( arguments.query.getBindings(), "select" );
         return this;
     }
@@ -605,19 +700,23 @@ component displayname="QueryBuilder" accessors="true" {
      * @return qb.models.Query.QueryBuilder
      */
     public QueryBuilder function addSelect( required any columns ) {
+        var newColumns = normalizeToArray( arguments.columns )
+            .map( ( column ) => applyColumnFormatter( column ) )
+            .map( ( column ) => mapToColumnType( column ) );
+        var selectedColumns = variables.columns.isEmpty() ? [] : arraySlice( variables.columns, 1 );
+
         if (
             variables.columns.isEmpty() ||
             (
                 variables.columns.len() == 1 && isSimpleValue( variables.columns[ 1 ].value ) && variables.columns[ 1 ].value == "*"
             )
         ) {
-            variables.columns = [];
+            selectedColumns = [];
         }
-        var newColumns = normalizeToArray( arguments.columns )
-            .map( ( column ) => applyColumnFormatter( column ) )
-            .map( ( column ) => mapToColumnType( column ) );
 
-        arrayAppend( variables.columns, newColumns, true );
+        arrayAppend( selectedColumns, newColumns, true );
+        validateUniqueSelectColumns( selectedColumns );
+        variables.columns = selectedColumns;
         return this;
     }
 
@@ -4697,6 +4796,7 @@ component displayname="QueryBuilder" accessors="true" {
             columnFormatter = isNull( getColumnFormatter() ) ? javacast( "null", "" ) : getColumnFormatter(),
             parentQuery = isNull( getParentQuery() ) ? javacast( "null", "" ) : getParentQuery(),
             defaultOptions = getDefaultOptions(),
+            validateDuplicateSelectColumns = getValidateDuplicateSelectColumns(),
             validateQueryExecuteReturnType = getValidateQueryExecuteReturnType(),
             collectQueryLog = getCollectQueryLog()
         );

--- a/tests/specs/Query/Abstract/BuilderSelectSpec.cfc
+++ b/tests/specs/Query/Abstract/BuilderSelectSpec.cfc
@@ -3,7 +3,7 @@ component extends="testbox.system.BaseSpec" {
     function run() {
         describe( "select methods", function() {
             beforeEach( function() {
-                variables.mockGrammar = getMockBox().createMock( "qb.models.Grammars.BaseGrammar" );
+                variables.mockGrammar = getMockBox().createMock( "qb.models.Grammars.BaseGrammar" ).init();
                 variables.query = new qb.models.Query.QueryBuilder( variables.mockGrammar );
             } );
 
@@ -42,7 +42,10 @@ component extends="testbox.system.BaseSpec" {
                 describe( "duplicate output name validation", function() {
                     it( "is disabled by default", function() {
                         expect( function() {
-                            query.select( [ "equipment.id", "racks.id" ] );
+                            query
+                                .select( [ "equipment.id", "racks.id" ] )
+                                .from( "equipment" )
+                                .toSQL();
                         } ).notToThrow();
                     } );
 
@@ -52,8 +55,10 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        validatingQuery.select( [ "equipment.id", "racks.id" ] ).from( "equipment" );
+
                         expect( function() {
-                            validatingQuery.select( [ "equipment.id", "racks.id" ] );
+                            validatingQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn", regex = "output name \[id\]" );
                     } );
 
@@ -63,8 +68,12 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        validatingQuery
+                            .select( [ "equipment.id AS equipmentId", "racks.id AS EquipmentID" ] )
+                            .from( "equipment" );
+
                         expect( function() {
-                            validatingQuery.select( [ "equipment.id AS equipmentId", "racks.id AS EquipmentID" ] );
+                            validatingQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn" );
                     } );
 
@@ -74,8 +83,12 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        validatingQuery
+                            .select( [ "equipment.id AS `equipmentId`", "racks.id AS equipmentId" ] )
+                            .from( "equipment" );
+
                         expect( function() {
-                            validatingQuery.select( [ "equipment.id AS `equipmentId`", "racks.id AS equipmentId" ] );
+                            validatingQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn" );
                     } );
 
@@ -86,7 +99,10 @@ component extends="testbox.system.BaseSpec" {
                         );
 
                         expect( function() {
-                            validatingQuery.select( [ "equipment.id AS equipmentId", "racks.id AS rackId" ] );
+                            validatingQuery
+                                .select( [ "equipment.id AS equipmentId", "racks.id AS rackId" ] )
+                                .from( "equipment" )
+                                .toSQL();
                         } ).notToThrow();
                     } );
 
@@ -97,7 +113,10 @@ component extends="testbox.system.BaseSpec" {
                         );
 
                         expect( function() {
-                            validatingQuery.select( [ "equipment.*", "racks.*" ] );
+                            validatingQuery
+                                .select( [ "equipment.*", "racks.*" ] )
+                                .from( "equipment" )
+                                .toSQL();
                         } ).notToThrow();
                     } );
 
@@ -107,8 +126,10 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        validatingQuery.selectRaw( [ "COUNT(*) AS total", "SUM(amount) AS total" ] ).from( "equipment" );
+
                         expect( function() {
-                            validatingQuery.selectRaw( [ "COUNT(*) AS total", "SUM(amount) AS total" ] );
+                            validatingQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn" );
                     } );
 
@@ -119,7 +140,10 @@ component extends="testbox.system.BaseSpec" {
                         );
 
                         expect( function() {
-                            validatingQuery.selectRaw( [ "CAST(id AS VARCHAR)", "CAST(name AS VARCHAR)" ] );
+                            validatingQuery
+                                .selectRaw( [ "CAST(id AS VARCHAR)", "CAST(name AS VARCHAR)" ] )
+                                .from( "equipment" )
+                                .toSQL();
                         } ).notToThrow();
                     } );
 
@@ -129,9 +153,30 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        validatingQuery
+                            .select( [ validatingQuery.jsonPath( "profile", [ "name" ], "name" ), "users.name" ] )
+                            .from( "users" );
+
                         expect( function() {
-                            validatingQuery.select( [ validatingQuery.jsonPath( "profile", [ "name" ], "name" ), "users.name" ] );
+                            validatingQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "does not infer output names for unaliased typed expressions", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = new qb.models.Grammars.MySQLGrammar( new qb.models.Query.QueryUtils() ),
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery
+                                .select( [
+                                    validatingQuery.jsonPath( "profile", [ "name" ] ),
+                                    validatingQuery.jsonPath( "metadata", [ "name" ] )
+                                ] )
+                                .from( "users" )
+                                .toSQL();
+                        } ).notToThrow();
                     } );
 
                     it( "propagates validation to new queries", function() {
@@ -140,9 +185,41 @@ component extends="testbox.system.BaseSpec" {
                             validateDuplicateSelectColumns = true
                         );
 
+                        var childQuery = validatingQuery
+                            .newQuery()
+                            .select( [ "equipment.id", "racks.id" ] )
+                            .from( "equipment" );
+
                         expect( function() {
-                            validatingQuery.newQuery().select( [ "equipment.id", "racks.id" ] );
+                            childQuery.toSQL();
                         } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "validates the final selection after a reselect", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery
+                                .select( [ "equipment.id", "racks.id" ] )
+                                .reselect( [ "equipment.id AS equipmentId", "racks.id AS rackId" ] )
+                                .from( "equipment" )
+                                .toSQL();
+                        } ).notToThrow();
+                    } );
+
+                    it( "does not validate columns excluded from aggregate output", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+                        validatingQuery.select( [ "equipment.id", "racks.id" ] ).from( "equipment" );
+
+                        expect( function() {
+                            validatingQuery.count( toSQL = true );
+                        } ).notToThrow();
                     } );
                 } );
             } );
@@ -176,9 +253,10 @@ component extends="testbox.system.BaseSpec" {
                         validateDuplicateSelectColumns = true
                     );
                     validatingQuery.select( "equipment.id" );
+                    validatingQuery.addSelect( "racks.id" ).from( "equipment" );
 
                     expect( function() {
-                        validatingQuery.addSelect( "racks.id" );
+                        validatingQuery.toSQL();
                     } ).toThrow( type = "DuplicateSelectColumn" );
                 } );
 
@@ -188,11 +266,14 @@ component extends="testbox.system.BaseSpec" {
                         validateDuplicateSelectColumns = true
                     );
                     validatingQuery.select( "users.id" );
+                    validatingQuery
+                        .subSelect( "id", function( subquery ) {
+                            subquery.from( "contacts" ).select( "contacts.id" );
+                        } )
+                        .from( "users" );
 
                     expect( function() {
-                        validatingQuery.subSelect( "id", function( subquery ) {
-                            subquery.from( "contacts" ).select( "contacts.id" );
-                        } );
+                        validatingQuery.toSQL();
                     } ).toThrow( type = "DuplicateSelectColumn" );
                 } );
             } );

--- a/tests/specs/Query/Abstract/BuilderSelectSpec.cfc
+++ b/tests/specs/Query/Abstract/BuilderSelectSpec.cfc
@@ -38,6 +38,113 @@ component extends="testbox.system.BaseSpec" {
                         expect( query.getColumns().map( ( c ) => c.value ) ).toBe( [ "::some_column::", "::another_column::" ] );
                     } );
                 } );
+
+                describe( "duplicate output name validation", function() {
+                    it( "is disabled by default", function() {
+                        expect( function() {
+                            query.select( [ "equipment.id", "racks.id" ] );
+                        } ).notToThrow();
+                    } );
+
+                    it( "throws for duplicate qualified column names when enabled", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ "equipment.id", "racks.id" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn", regex = "output name \[id\]" );
+                    } );
+
+                    it( "compares output names case-insensitively", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ "equipment.id AS equipmentId", "racks.id AS EquipmentID" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "normalizes quoted output names", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ "equipment.id AS `equipmentId`", "racks.id AS equipmentId" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "allows unique aliases", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ "equipment.id AS equipmentId", "racks.id AS rackId" ] );
+                        } ).notToThrow();
+                    } );
+
+                    it( "ignores wildcard selections whose output names are not known", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ "equipment.*", "racks.*" ] );
+                        } ).notToThrow();
+                    } );
+
+                    it( "validates explicit aliases on raw expressions", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.selectRaw( [ "COUNT(*) AS total", "SUM(amount) AS total" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "does not treat SQL AS operators as output aliases", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.selectRaw( [ "CAST(id AS VARCHAR)", "CAST(name AS VARCHAR)" ] );
+                        } ).notToThrow();
+                    } );
+
+                    it( "validates typed column aliases", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.select( [ validatingQuery.jsonPath( "profile", [ "name" ], "name" ), "users.name" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+
+                    it( "propagates validation to new queries", function() {
+                        var validatingQuery = new qb.models.Query.QueryBuilder(
+                            grammar = variables.mockGrammar,
+                            validateDuplicateSelectColumns = true
+                        );
+
+                        expect( function() {
+                            validatingQuery.newQuery().select( [ "equipment.id", "racks.id" ] );
+                        } ).toThrow( type = "DuplicateSelectColumn" );
+                    } );
+                } );
             } );
 
             describe( "addSelect()", function() {
@@ -61,6 +168,32 @@ component extends="testbox.system.BaseSpec" {
                         query.addSelect( [ "::another_column::", "::yet_another_column::" ] );
                         expect( query.getColumns().map( ( c ) => c.value ) ).toBe( [ "::some_column::", "::another_column::", "::yet_another_column::" ] );
                     } );
+                } );
+
+                it( "validates duplicate output names across calls", function() {
+                    var validatingQuery = new qb.models.Query.QueryBuilder(
+                        grammar = variables.mockGrammar,
+                        validateDuplicateSelectColumns = true
+                    );
+                    validatingQuery.select( "equipment.id" );
+
+                    expect( function() {
+                        validatingQuery.addSelect( "racks.id" );
+                    } ).toThrow( type = "DuplicateSelectColumn" );
+                } );
+
+                it( "validates subselect aliases against selected columns", function() {
+                    var validatingQuery = new qb.models.Query.QueryBuilder(
+                        grammar = variables.mockGrammar,
+                        validateDuplicateSelectColumns = true
+                    );
+                    validatingQuery.select( "users.id" );
+
+                    expect( function() {
+                        validatingQuery.subSelect( "id", function( subquery ) {
+                            subquery.from( "contacts" ).select( "contacts.id" );
+                        } );
+                    } ).toThrow( type = "DuplicateSelectColumn" );
                 } );
             } );
 


### PR DESCRIPTION
## Summary

- add opt-in validation for duplicate select output names
- validate the final selection during SQL compilation so queries can be built and corrected out of order
- detect qualified columns, explicit aliases, subselect aliases, and explicitly aliased typed columns case-insensitively
- skip wildcards and expressions without explicit aliases whose output names cannot be determined safely
- document enabling the validation in development and leaving it disabled in production

## Why

CFML query results silently collapse duplicate output labels, which can discard selected values when rows are converted to structs. This validation catches statically identifiable collisions before execution and recommends aliases.

## Validation

- Added the failing tests first: 5 expected failures before implementation
- Focused select suite: 24 passed
- Full Lucee suite: 2,666 passed, 0 failed, 3 skipped
- CFFormat check
- git diff --check

Refs #105