### PR TITLE
feat(QueryBuilder): add whereInBulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,22 @@ For large value collections, `whereInBulk` serializes the values into one bound 
 ```cfc
 query
     .from( "users" )
+    .whereInBulk( "id", userIds )
+    .get();
+```
+
+qb infers a common type from the values and translates it to the active database grammar. Matching `cfsqltype` values in query parameter structs are preserved. Mixed values fall back to the grammar's string type.
+
+You can pass an explicit `sqlType` as the third argument when the column needs a more specific database type, such as `BIGINT`, `UUID`, or a particular decimal precision:
+
+```cfc
+query
+    .from( "users" )
     .whereInBulk( "id", userIds, "BIGINT" )
     .get();
 ```
 
-The `sqlType` should match the constrained column so the database can avoid implicit conversions. `whereNotInBulk`, `andWhereInBulk`, `orWhereInBulk`, `andWhereNotInBulk`, and `orWhereNotInBulk` are also available.
+The explicit `sqlType` should match the constrained column so the database can avoid implicit conversions. `whereNotInBulk`, `andWhereInBulk`, `orWhereInBulk`, `andWhereNotInBulk`, and `orWhereNotInBulk` are also available.
 
 Bulk value expansion is supported by these grammars and database features:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ q = queryExecute(
 
 qb enables you to explore new ways of organizing your code by letting you pass around a query builder object that will compile down to the right SQL without you having to keep track of the order, whitespace, or other SQL gotchas!
 
+## Bulk WHERE IN
+
+For large value collections, `whereInBulk` serializes the values into one bound parameter and lets the active grammar expand them into rows. This avoids database parameter limits without changing the behavior or performance of regular `whereIn` calls.
+
+```cfc
+query
+    .from( "users" )
+    .whereInBulk( "id", userIds, "BIGINT" )
+    .get();
+```
+
+The `sqlType` should match the constrained column so the database can avoid implicit conversions. `whereNotInBulk`, `andWhereInBulk`, `orWhereInBulk`, `andWhereNotInBulk`, and `orWhereNotInBulk` are also available.
+
+Bulk value expansion is supported by these grammars and database features:
+
++ SQL Server 2016+ using `OPENJSON`; database compatibility level 130+ is required
++ PostgreSQL 9.4+ using `JSONB_ARRAY_ELEMENTS_TEXT`
++ MySQL 8.0.4+ and MariaDB 10.6+ using `JSON_TABLE`
++ Oracle Database 12c Release 1 (12.1.0.2)+ using `JSON_TABLE`
++ SQLite with JSON functions enabled; they are built in by default as of SQLite 3.38.0
+
+Derby does not support bulk value expansion and throws an `UnsupportedOperation` exception for non-empty collections.
+
 ## Development Validation
 
 qb can detect statically identifiable duplicate select output names before they are silently collapsed by CFML query results. Enable this validation in development and leave it disabled in production:

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -652,6 +652,35 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     /**
+     * Compiles a bulk IN or NOT IN statement using one serialized binding.
+     *
+     * @query The Builder instance.
+     * @where The where clause to compile.
+     *
+     * @return string
+     */
+    private string function whereInBulk( required QueryBuilder query, required struct where ) {
+        if ( arguments.where.isEmpty ) {
+            return arguments.where.negate ? "1 = 1" : "0 = 1";
+        }
+
+        var operator = arguments.where.negate ? "NOT IN" : "IN";
+        return "#wrapColumn( arguments.where.column )# #operator# (#compileWhereInBulkValues( arguments.where.sqlType )#)";
+    }
+
+    /**
+     * Compiles the row-producing subquery for a bulk IN statement.
+     * Grammars with a native single-parameter strategy should override this method.
+     *
+     * @sqlType The database SQL type to use for each value.
+     *
+     * @return string
+     */
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        throw( type = "UnsupportedOperation", message = "This grammar does not support bulk IN statements." );
+    }
+
+    /**
      * Compiles a in subselect where statement.
      *
      * @query The Builder instance.

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -681,6 +681,17 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     /**
+     * Maps an inferred CF SQL type to a database-native type for a bulk IN statement.
+     *
+     * @sqlType The inferred CF SQL type.
+     *
+     * @return string
+     */
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        return reReplaceNoCase( trim( arguments.sqlType ), "^CF_SQL_", "" ).uCase();
+    }
+
+    /**
      * Compiles a in subselect where statement.
      *
      * @query The Builder instance.

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -4,6 +4,27 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` #arguments.sqlType# PATH '$')) AS `qb_bulk_values`";
     }
 
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        var normalizedType = super.resolveWhereInBulkSqlType( arguments.sqlType );
+        switch ( normalizedType ) {
+            case "CHAR":
+            case "NCHAR":
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "LONGVARCHAR":
+            case "LONGNVARCHAR":
+            case "CLOB":
+            case "NCLOB":
+                return "VARCHAR(4000)";
+            case "TIMESTAMP":
+                return "DATETIME(6)";
+            case "BOOLEAN":
+                return "TINYINT";
+            default:
+                return normalizedType;
+        }
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_UNQUOTE(JSON_EXTRACT(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#'))";
     }

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -1,5 +1,9 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        return "SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` #arguments.sqlType# PATH '$')) AS `qb_bulk_values`";
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_UNQUOTE(JSON_EXTRACT(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#'))";
     }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -1,5 +1,9 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        return "SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" #arguments.sqlType# PATH '$')) ""QB_BULK_VALUES""";
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_VALUE(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -4,6 +4,34 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" #arguments.sqlType# PATH '$')) ""QB_BULK_VALUES""";
     }
 
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        var normalizedType = super.resolveWhereInBulkSqlType( arguments.sqlType );
+        switch ( normalizedType ) {
+            case "CHAR":
+            case "NCHAR":
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "LONGVARCHAR":
+            case "LONGNVARCHAR":
+            case "CLOB":
+            case "NCLOB":
+                return "VARCHAR2(4000)";
+            case "TINYINT":
+            case "SMALLINT":
+            case "INTEGER":
+                return "NUMBER";
+            case "BIGINT":
+                return "NUMBER(19, 0)";
+            case "DECIMAL":
+            case "NUMERIC":
+            case "BIT":
+            case "BOOLEAN":
+                return "NUMBER";
+            default:
+                return normalizedType;
+        }
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_VALUE(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -4,6 +4,27 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "SELECT CAST(""value"" AS #arguments.sqlType#) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value"")";
     }
 
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        var normalizedType = super.resolveWhereInBulkSqlType( arguments.sqlType );
+        switch ( normalizedType ) {
+            case "CHAR":
+            case "NCHAR":
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "LONGVARCHAR":
+            case "LONGNVARCHAR":
+            case "CLOB":
+            case "NCLOB":
+                return "TEXT";
+            case "OTHER":
+            case "BIT":
+            case "TINYINT":
+                return "BOOLEAN";
+            default:
+                return normalizedType;
+        }
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return compilePostgresJsonTraversal( arguments.jsonPath, true );
     }

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -1,5 +1,9 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        return "SELECT CAST(""value"" AS #arguments.sqlType#) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value"")";
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return compilePostgresJsonTraversal( arguments.jsonPath, true );
     }

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -4,6 +4,40 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         return "SELECT CAST(""value"" AS #arguments.sqlType#) FROM JSON_EACH(?)";
     }
 
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        var normalizedType = super.resolveWhereInBulkSqlType( arguments.sqlType );
+        switch ( normalizedType ) {
+            case "CHAR":
+            case "NCHAR":
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "LONGVARCHAR":
+            case "LONGNVARCHAR":
+            case "CLOB":
+            case "NCLOB":
+            case "DATE":
+            case "TIME":
+            case "TIMESTAMP":
+                return "TEXT";
+            case "BIT":
+            case "BOOLEAN":
+            case "TINYINT":
+            case "SMALLINT":
+            case "INTEGER":
+            case "BIGINT":
+            case "OTHER":
+                return "INTEGER";
+            case "DECIMAL":
+            case "NUMERIC":
+            case "REAL":
+            case "FLOAT":
+            case "DOUBLE":
+                return "REAL";
+            default:
+                return normalizedType;
+        }
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_EXTRACT(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -1,5 +1,9 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton {
 
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        return "SELECT CAST(""value"" AS #arguments.sqlType#) FROM JSON_EACH(?)";
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_EXTRACT(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -1,5 +1,9 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
 
+    public string function compileWhereInBulkValues( required string sqlType ) {
+        return "SELECT [value] FROM OPENJSON(?) WITH ([value] #arguments.sqlType# '$')";
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_VALUE(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -4,6 +4,27 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return "SELECT [value] FROM OPENJSON(?) WITH ([value] #arguments.sqlType# '$')";
     }
 
+    public string function resolveWhereInBulkSqlType( required string sqlType ) {
+        var normalizedType = super.resolveWhereInBulkSqlType( arguments.sqlType );
+        switch ( normalizedType ) {
+            case "CHAR":
+            case "NCHAR":
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "LONGVARCHAR":
+            case "LONGNVARCHAR":
+            case "CLOB":
+            case "NCLOB":
+                return "NVARCHAR(MAX)";
+            case "TIMESTAMP":
+                return "DATETIME2";
+            case "BOOLEAN":
+                return "BIT";
+            default:
+                return normalizedType;
+        }
+    }
+
     public string function compileJsonScalar( required struct jsonPath ) {
         return "JSON_VALUE(#wrapJsonColumn( arguments.jsonPath )#, '#buildJsonPath( arguments.jsonPath.path )#')";
     }

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2376,7 +2376,7 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereInBulk(
         required column,
         required values,
-        string sqlType = "__QB_INFER_SQL_TYPE__",
+        any sqlType = javacast( "null", "" ),
         string combinator = "and",
         boolean negate = false
     ) {
@@ -2390,7 +2390,7 @@ component displayname="QueryBuilder" accessors="true" {
             return getUtils().extractBinding( arguments.value, variables.grammar );
         } );
 
-        if ( arguments.sqlType == "__QB_INFER_SQL_TYPE__" ) {
+        if ( isNull( arguments.sqlType ) ) {
             arguments.sqlType = variables.grammar.resolveWhereInBulkSqlType(
                 getUtils().inferSqlType( arguments.values, variables.grammar )
             );
@@ -2451,7 +2451,7 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereNotInBulk(
         required column,
         required values,
-        string sqlType = "__QB_INFER_SQL_TYPE__",
+        any sqlType = javacast( "null", "" ),
         string combinator = "and"
     ) {
         arguments.negate = true;

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2367,7 +2367,7 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @column The name of the column with which to constrain the query.
      * @values The values to serialize into the single bound parameter.
-     * @sqlType The database SQL type to use for each expanded value.
+     * @sqlType The database SQL type to use for each expanded value. Inferred from the values when omitted.
      * @combinator The boolean combinator for the clause (e.g. "and" or "or"). Default: "and"
      * @negate False for IN, True for NOT IN. Default: false.
      *
@@ -2376,11 +2376,32 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereInBulk(
         required column,
         required values,
-        required string sqlType,
+        string sqlType,
         string combinator = "and",
         boolean negate = false
     ) {
         arguments.values = normalizeToArray( arguments.values );
+
+        if ( arguments.values.some( getUtils().isExpression ) ) {
+            throw( type = "InvalidBulkValue", message = "Bulk IN values cannot contain SQL expressions." );
+        }
+
+        var extractedBindings = arguments.values.map( function( value ) {
+            return getUtils().extractBinding( arguments.value, variables.grammar );
+        } );
+
+        if ( !structKeyExists( arguments, "sqlType" ) ) {
+            var inferredSqlType = extractedBindings.isEmpty() ? "VARCHAR" : extractedBindings[ 1 ].cfsqltype;
+            if (
+                extractedBindings.some( function( binding ) {
+                    return compareNoCase( arguments.binding.cfsqltype, inferredSqlType ) != 0;
+                } )
+            ) {
+                inferredSqlType = "VARCHAR";
+            }
+            arguments.sqlType = variables.grammar.resolveWhereInBulkSqlType( inferredSqlType );
+        }
+
         arguments.sqlType = trim( arguments.sqlType );
 
         if (
@@ -2396,10 +2417,6 @@ component displayname="QueryBuilder" accessors="true" {
             );
         }
 
-        if ( arguments.values.some( getUtils().isExpression ) ) {
-            throw( type = "InvalidBulkValue", message = "Bulk IN values cannot contain SQL expressions." );
-        }
-
         variables.wheres.append( {
             type: "inBulk",
             column: mapToColumnType( applyColumnFormatter( arguments.column ) ),
@@ -2410,8 +2427,7 @@ component displayname="QueryBuilder" accessors="true" {
         } );
 
         if ( !arguments.values.isEmpty() ) {
-            var serializedValues = arguments.values.map( function( value ) {
-                var binding = getUtils().extractBinding( arguments.value, variables.grammar );
+            var serializedValues = extractedBindings.map( function( binding ) {
                 return binding.null ? javacast( "null", "" ) : binding.value;
             } );
             addBindings(
@@ -2433,7 +2449,7 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @column The name of the column with which to constrain the query.
      * @values The values to serialize into the single bound parameter.
-     * @sqlType The database SQL type to use for each expanded value.
+     * @sqlType The database SQL type to use for each expanded value. Inferred from the values when omitted.
      * @combinator The boolean combinator for the clause (e.g. "and" or "or"). Default: "and"
      *
      * @return qb.models.Query.QueryBuilder
@@ -2441,7 +2457,7 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereNotInBulk(
         required column,
         required values,
-        required string sqlType,
+        string sqlType,
         string combinator = "and"
     ) {
         arguments.negate = true;

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2391,15 +2391,9 @@ component displayname="QueryBuilder" accessors="true" {
         } );
 
         if ( arguments.sqlType == "__QB_INFER_SQL_TYPE__" ) {
-            var inferredSqlType = extractedBindings.isEmpty() ? "VARCHAR" : extractedBindings[ 1 ].cfsqltype;
-            if (
-                extractedBindings.some( function( binding ) {
-                    return compareNoCase( arguments.binding.cfsqltype, inferredSqlType ) != 0;
-                } )
-            ) {
-                inferredSqlType = "VARCHAR";
-            }
-            arguments.sqlType = variables.grammar.resolveWhereInBulkSqlType( inferredSqlType );
+            arguments.sqlType = variables.grammar.resolveWhereInBulkSqlType(
+                getUtils().inferSqlType( arguments.values, variables.grammar )
+            );
         }
 
         arguments.sqlType = trim( arguments.sqlType );

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2362,6 +2362,93 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
+     * Adds a WHERE IN clause that serializes all values into one bound parameter.
+     * The active grammar determines how the parameter is expanded into rows.
+     *
+     * @column The name of the column with which to constrain the query.
+     * @values The values to serialize into the single bound parameter.
+     * @sqlType The database SQL type to use for each expanded value.
+     * @combinator The boolean combinator for the clause (e.g. "and" or "or"). Default: "and"
+     * @negate False for IN, True for NOT IN. Default: false.
+     *
+     * @return qb.models.Query.QueryBuilder
+     */
+    public QueryBuilder function whereInBulk(
+        required column,
+        required values,
+        required string sqlType,
+        string combinator = "and",
+        boolean negate = false
+    ) {
+        arguments.values = normalizeToArray( arguments.values );
+        arguments.sqlType = trim( arguments.sqlType );
+
+        if (
+            arguments.sqlType == "" ||
+            !reFindNoCase(
+                "^[a-z][a-z0-9_]*(?:\s+[a-z][a-z0-9_]*)*(?:\s*\(\s*(?:max|\d+)(?:\s*,\s*\d+)?\s*\))?$",
+                arguments.sqlType
+            )
+        ) {
+            throw(
+                type = "InvalidSQLType",
+                message = "Invalid SQL type [#arguments.sqlType#] for a bulk IN statement."
+            );
+        }
+
+        if ( arguments.values.some( getUtils().isExpression ) ) {
+            throw( type = "InvalidBulkValue", message = "Bulk IN values cannot contain SQL expressions." );
+        }
+
+        variables.wheres.append( {
+            type: "inBulk",
+            column: mapToColumnType( applyColumnFormatter( arguments.column ) ),
+            sqlType: arguments.sqlType,
+            isEmpty: arguments.values.isEmpty(),
+            negate: arguments.negate,
+            combinator: arguments.combinator
+        } );
+
+        if ( !arguments.values.isEmpty() ) {
+            var serializedValues = arguments.values.map( function( value ) {
+                var binding = getUtils().extractBinding( arguments.value, variables.grammar );
+                return binding.null ? javacast( "null", "" ) : binding.value;
+            } );
+            addBindings(
+                [
+                    getUtils().extractBinding(
+                        { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
+                        variables.grammar
+                    )
+                ],
+                "where"
+            );
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds a WHERE NOT IN clause that serializes all values into one bound parameter.
+     *
+     * @column The name of the column with which to constrain the query.
+     * @values The values to serialize into the single bound parameter.
+     * @sqlType The database SQL type to use for each expanded value.
+     * @combinator The boolean combinator for the clause (e.g. "and" or "or"). Default: "and"
+     *
+     * @return qb.models.Query.QueryBuilder
+     */
+    public QueryBuilder function whereNotInBulk(
+        required column,
+        required values,
+        required string sqlType,
+        string combinator = "and"
+    ) {
+        arguments.negate = true;
+        return whereInBulk( argumentCollection = arguments );
+    }
+
+    /**
      * Adds a WHERE IN clause to the query using a subselect.  To call this using the public api, pass a closure to `whereIn` as the second argument (`values`).
      *
      * @column The name of the column with which to constrain the query.

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -2376,7 +2376,7 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereInBulk(
         required column,
         required values,
-        string sqlType,
+        string sqlType = "__QB_INFER_SQL_TYPE__",
         string combinator = "and",
         boolean negate = false
     ) {
@@ -2390,7 +2390,7 @@ component displayname="QueryBuilder" accessors="true" {
             return getUtils().extractBinding( arguments.value, variables.grammar );
         } );
 
-        if ( !structKeyExists( arguments, "sqlType" ) ) {
+        if ( arguments.sqlType == "__QB_INFER_SQL_TYPE__" ) {
             var inferredSqlType = extractedBindings.isEmpty() ? "VARCHAR" : extractedBindings[ 1 ].cfsqltype;
             if (
                 extractedBindings.some( function( binding ) {
@@ -2457,7 +2457,7 @@ component displayname="QueryBuilder" accessors="true" {
     public QueryBuilder function whereNotInBulk(
         required column,
         required values,
-        string sqlType,
+        string sqlType = "__QB_INFER_SQL_TYPE__",
         string combinator = "and"
     ) {
         arguments.negate = true;

--- a/models/Query/QueryUtils.cfc
+++ b/models/Query/QueryUtils.cfc
@@ -199,6 +199,18 @@ component singleton displayname="QueryUtils" accessors="true" {
             );
         }
 
+        if ( isStruct( value ) ) {
+            if ( structKeyExists( value, "cfsqltype" ) ) {
+                return value.cfsqltype;
+            }
+
+            if ( structKeyExists( value, "sqltype" ) ) {
+                return value.sqltype;
+            }
+
+            return structKeyExists( value, "value" ) ? inferSqlType( value.value, grammar ) : "VARCHAR";
+        }
+
         if ( checkIsActuallyNumeric( value ) ) {
             return deriveNumericSqlType( value );
         }

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -954,14 +954,12 @@ component extends="testbox.system.BaseSpec" {
                         describe( "bulk values", function() {
                             it( "binds an array as a single parameter", function() {
                                 testCase( function( builder ) {
-                                    builder.from( "users" ).whereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                    builder.from( "users" ).whereInBulk( "id", [ 1, 2, 3 ] );
                                 }, whereInBulk() );
                             } );
 
                             it( "uses a large text binding for the serialized values", function() {
-                                var builder = getBuilder()
-                                    .from( "users" )
-                                    .whereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                var builder = getBuilder().from( "users" ).whereInBulk( "id", [ 1, 2, 3 ] );
                                 var bindings = builder.getBindings();
                                 expect( bindings ).toHaveLength( 1 );
                                 expect( bindings[ 1 ].value ).toBe( "[1,2,3]" );
@@ -978,10 +976,50 @@ component extends="testbox.system.BaseSpec" {
                                                 { value: 1, cfsqltype: "INTEGER" },
                                                 { value: 2, cfsqltype: "INTEGER" },
                                                 { value: 3, cfsqltype: "INTEGER" }
-                                            ],
-                                            bulkSqlType()
+                                            ]
                                         );
                                 }, whereInBulk() );
+                            } );
+
+                            it( "infers string values using the grammar-specific string type", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "status", [ "active", "pending" ] );
+                                }, whereInBulkStrings() );
+                            } );
+
+                            it( "falls back to the grammar-specific string type for mixed values", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "externalId", [ 1, "two" ] );
+                                }, whereInBulkMixed() );
+                            } );
+
+                            it( "infers boolean values using the grammar-specific boolean type", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "active", [ true, false ] );
+                                }, whereInBulkBooleans() );
+                            } );
+
+                            it( "uses matching query parameter types as the inferred type", function() {
+                                testCase( function( builder ) {
+                                    builder
+                                        .from( "users" )
+                                        .whereInBulk(
+                                            "id",
+                                            [ { value: 1, cfsqltype: "BIGINT" }, { value: 2, cfsqltype: "BIGINT" } ]
+                                        );
+                                }, whereInBulkBigInt() );
+                            } );
+
+                            it( "allows an explicit SQL type to override inference", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "id", [ 1, 2, 3 ], bulkExplicitSqlType() );
+                                }, whereInBulkExplicitType() );
+                            } );
+
+                            it( "maps inferred timestamp types for the active grammar", function() {
+                                expect( getBuilder().getGrammar().resolveWhereInBulkSqlType( "TIMESTAMP" ) ).toBe(
+                                    bulkTimestampSqlType()
+                                );
                             } );
 
                             it( "supports dynamic or where shortcuts", function() {
@@ -989,31 +1027,31 @@ component extends="testbox.system.BaseSpec" {
                                     builder
                                         .from( "users" )
                                         .where( "active", 1 )
-                                        .orWhereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                        .orWhereInBulk( "id", [ 1, 2, 3 ] );
                                 }, orWhereInBulk() );
                             } );
 
                             it( "supports negated bulk values", function() {
                                 testCase( function( builder ) {
-                                    builder.from( "users" ).whereNotInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                    builder.from( "users" ).whereNotInBulk( "id", [ 1, 2, 3 ] );
                                 }, whereNotInBulk() );
                             } );
 
                             it( "handles empty bulk values without a binding", function() {
                                 testCase( function( builder ) {
-                                    builder.from( "users" ).whereInBulk( "id", [], bulkSqlType() );
+                                    builder.from( "users" ).whereInBulk( "id", [] );
                                 }, whereInBulkEmpty() );
                             } );
 
                             it( "handles empty negated bulk values without a binding", function() {
                                 testCase( function( builder ) {
-                                    builder.from( "users" ).whereNotInBulk( "id", [], bulkSqlType() );
+                                    builder.from( "users" ).whereNotInBulk( "id", [] );
                                 }, whereNotInBulkEmpty() );
                             } );
 
                             it( "rejects SQL expressions in bulk values", function() {
                                 expect( function() {
-                                    getBuilder().whereInBulk( "id", [ getBuilder().raw( "SELECT 1" ) ], bulkSqlType() );
+                                    getBuilder().whereInBulk( "id", [ getBuilder().raw( "SELECT 1" ) ] );
                                 } ).toThrow( type = "InvalidBulkValue" );
                             } );
 
@@ -3294,8 +3332,12 @@ component extends="testbox.system.BaseSpec" {
         throw( "Must be implemented in a subclass" );
     }
 
-    string function bulkSqlType() {
-        return "INTEGER";
+    string function bulkTimestampSqlType() {
+        return "TIMESTAMP";
+    }
+
+    string function bulkExplicitSqlType() {
+        return "BIGINT";
     }
 
     private array function getTestBindings( required QueryBuilder builder, boolean withFullBindings = false ) {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1060,6 +1060,12 @@ component extends="testbox.system.BaseSpec" {
                                     getBuilder().whereInBulk( "id", [ 1, 2, 3 ], "INTEGER); DROP TABLE users; --" );
                                 } ).toThrow( type = "InvalidSQLType" );
                             } );
+
+                            it( "rejects an explicitly empty SQL type", function() {
+                                expect( function() {
+                                    getBuilder().whereInBulk( "id", [ 1, 2, 3 ], "" );
+                                } ).toThrow( type = "InvalidSQLType" );
+                            } );
                         } );
                     } );
 

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -1016,6 +1016,12 @@ component extends="testbox.system.BaseSpec" {
                                 }, whereInBulkExplicitType() );
                             } );
 
+                            it( "infers the SQL type when explicitly passed null", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "id", [ 1, 2, 3 ], javacast( "null", "" ) );
+                                }, whereInBulk() );
+                            } );
+
                             it( "maps inferred timestamp types for the active grammar", function() {
                                 expect( getBuilder().getGrammar().resolveWhereInBulkSqlType( "TIMESTAMP" ) ).toBe(
                                     bulkTimestampSqlType()

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -950,6 +950,79 @@ component extends="testbox.system.BaseSpec" {
                                     );
                             }, whereInBuilderInstance() );
                         } );
+
+                        describe( "bulk values", function() {
+                            it( "binds an array as a single parameter", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                }, whereInBulk() );
+                            } );
+
+                            it( "uses a large text binding for the serialized values", function() {
+                                var builder = getBuilder()
+                                    .from( "users" )
+                                    .whereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                var bindings = builder.getBindings();
+                                expect( bindings ).toHaveLength( 1 );
+                                expect( bindings[ 1 ].value ).toBe( "[1,2,3]" );
+                                expect( bindings[ 1 ].cfsqltype ).toBe( "LONGVARCHAR" );
+                            } );
+
+                            it( "serializes values from query parameter structs", function() {
+                                testCase( function( builder ) {
+                                    builder
+                                        .from( "users" )
+                                        .whereInBulk(
+                                            "id",
+                                            [
+                                                { value: 1, cfsqltype: "INTEGER" },
+                                                { value: 2, cfsqltype: "INTEGER" },
+                                                { value: 3, cfsqltype: "INTEGER" }
+                                            ],
+                                            bulkSqlType()
+                                        );
+                                }, whereInBulk() );
+                            } );
+
+                            it( "supports dynamic or where shortcuts", function() {
+                                testCase( function( builder ) {
+                                    builder
+                                        .from( "users" )
+                                        .where( "active", 1 )
+                                        .orWhereInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                }, orWhereInBulk() );
+                            } );
+
+                            it( "supports negated bulk values", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereNotInBulk( "id", [ 1, 2, 3 ], bulkSqlType() );
+                                }, whereNotInBulk() );
+                            } );
+
+                            it( "handles empty bulk values without a binding", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereInBulk( "id", [], bulkSqlType() );
+                                }, whereInBulkEmpty() );
+                            } );
+
+                            it( "handles empty negated bulk values without a binding", function() {
+                                testCase( function( builder ) {
+                                    builder.from( "users" ).whereNotInBulk( "id", [], bulkSqlType() );
+                                }, whereNotInBulkEmpty() );
+                            } );
+
+                            it( "rejects SQL expressions in bulk values", function() {
+                                expect( function() {
+                                    getBuilder().whereInBulk( "id", [ getBuilder().raw( "SELECT 1" ) ], bulkSqlType() );
+                                } ).toThrow( type = "InvalidBulkValue" );
+                            } );
+
+                            it( "rejects unsafe SQL types", function() {
+                                expect( function() {
+                                    getBuilder().whereInBulk( "id", [ 1, 2, 3 ], "INTEGER); DROP TABLE users; --" );
+                                } ).toThrow( type = "InvalidSQLType" );
+                            } );
+                        } );
                     } );
 
                     describe( "where like shortcuts", function() {
@@ -3219,6 +3292,10 @@ component extends="testbox.system.BaseSpec" {
 
     private function getBuilder() {
         throw( "Must be implemented in a subclass" );
+    }
+
+    string function bulkSqlType() {
+        return "INTEGER";
     }
 
     private array function getTestBindings( required QueryBuilder builder, boolean withFullBindings = false ) {

--- a/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryUtilsSpec.cfc
@@ -172,6 +172,37 @@ component extends="testbox.system.BaseSpec" {
                     expect( utils.inferSqlType( [ 1, 2 ], variables.mockGrammar ) ).toBe( "INTEGER" );
                 } );
 
+                it( "uses matching cfsqltypes from query parameter structs", function() {
+                    expect(
+                        utils.inferSqlType(
+                            [ { value: 1, cfsqltype: "BIGINT" }, { value: 2, cfsqltype: "BIGINT" } ],
+                            variables.mockGrammar
+                        )
+                    ).toBe( "BIGINT" );
+                } );
+
+                it( "uses matching sqltypes from query parameter structs", function() {
+                    expect(
+                        utils.inferSqlType(
+                            [ { value: 1, sqltype: "BIGINT" }, { value: 2, sqltype: "BIGINT" } ],
+                            variables.mockGrammar
+                        )
+                    ).toBe( "BIGINT" );
+                } );
+
+                it( "infers values from untyped query parameter structs", function() {
+                    expect( utils.inferSqlType( [ { value: 1 }, { value: 2 } ], variables.mockGrammar ) ).toBe( "INTEGER" );
+                } );
+
+                it( "defaults to VARCHAR when query parameter struct types differ", function() {
+                    expect(
+                        utils.inferSqlType(
+                            [ { value: 1, cfsqltype: "INTEGER" }, { value: 2, cfsqltype: "BIGINT" } ],
+                            variables.mockGrammar
+                        )
+                    ).toBe( "VARCHAR" );
+                } );
+
                 it( "but defaults to VARCHAR if they are different", function() {
                     expect(
                         utils.inferSqlType(

--- a/tests/specs/Query/DerbyQueryBuilderSpec.cfc
+++ b/tests/specs/Query/DerbyQueryBuilderSpec.cfc
@@ -344,6 +344,26 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { exception: "UnsupportedOperation" };
     }
 
+    function whereInBulkStrings() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereInBulkMixed() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereInBulkBooleans() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereInBulkBigInt() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereInBulkExplicitType() {
+        return { exception: "UnsupportedOperation" };
+    }
+
     function orWhereInBulk() {
         return { exception: "UnsupportedOperation" };
     }

--- a/tests/specs/Query/DerbyQueryBuilderSpec.cfc
+++ b/tests/specs/Query/DerbyQueryBuilderSpec.cfc
@@ -340,6 +340,26 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function orWhereInBulk() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereNotInBulk() {
+        return { exception: "UnsupportedOperation" };
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return {
             sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)",

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -334,6 +334,35 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM `users` WHERE `id` IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `id` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` INTEGER PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function orWhereInBulk() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `active` = ? OR `id` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` INTEGER PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ 1, "[1,2,3]" ]
+        };
+    }
+
+    function whereNotInBulk() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `id` NOT IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` INTEGER PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM `users` WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM `users` WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return { sql: "SELECT * FROM `users` WHERE `email` = ? OR `id` IN (?, ?, ?)", bindings: [ "foo", 1, 2, 3 ] };
     }

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -341,6 +341,45 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function whereInBulkStrings() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `status` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` VARCHAR(4000) PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[""active"",""pending""]" ]
+        };
+    }
+
+    function whereInBulkMixed() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `externalId` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` VARCHAR(4000) PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,""two""]" ]
+        };
+    }
+
+    function whereInBulkBooleans() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `active` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` TINYINT PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,0]" ]
+        };
+    }
+
+    function whereInBulkBigInt() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `id` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` BIGINT PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,2]" ]
+        };
+    }
+
+    function whereInBulkExplicitType() {
+        return {
+            sql: "SELECT * FROM `users` WHERE `id` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` BIGINT PATH '$')) AS `qb_bulk_values`)",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function bulkTimestampSqlType() {
+        return "DATETIME(6)";
+    }
+
     function orWhereInBulk() {
         return {
             sql: "SELECT * FROM `users` WHERE `active` = ? OR `id` IN (SELECT `value` FROM JSON_TABLE(?, '$[*]' COLUMNS(`value` INTEGER PATH '$')) AS `qb_bulk_values`)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -346,6 +346,39 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM ""USERS"" WHERE ""ID"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function orWhereInBulk() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ACTIVE"" = ? OR ""ID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ 1, "[1,2,3]" ]
+        };
+    }
+
+    function whereNotInBulk() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ID"" NOT IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function bulkSqlType() {
+        return "NUMBER";
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM ""USERS"" WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM ""USERS"" WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return {
             sql: "SELECT * FROM ""USERS"" WHERE ""EMAIL"" = ? OR ""ID"" IN (?, ?, ?)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -353,6 +353,41 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function whereInBulkStrings() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""STATUS"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" VARCHAR2(4000) PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[""active"",""pending""]" ]
+        };
+    }
+
+    function whereInBulkMixed() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""EXTERNALID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" VARCHAR2(4000) PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,""two""]" ]
+        };
+    }
+
+    function whereInBulkBooleans() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ACTIVE"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,0]" ]
+        };
+    }
+
+    function whereInBulkBigInt() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER(19, 0) PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,2]" ]
+        };
+    }
+
+    function whereInBulkExplicitType() {
+        return {
+            sql: "SELECT * FROM ""USERS"" WHERE ""ID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER(19, 0) PATH '$')) ""QB_BULK_VALUES"")",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
     function orWhereInBulk() {
         return {
             sql: "SELECT * FROM ""USERS"" WHERE ""ACTIVE"" = ? OR ""ID"" IN (SELECT ""VALUE"" FROM JSON_TABLE(?, '$[*]' COLUMNS(""VALUE"" NUMBER PATH '$')) ""QB_BULK_VALUES"")",
@@ -367,8 +402,8 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
-    function bulkSqlType() {
-        return "NUMBER";
+    function bulkExplicitSqlType() {
+        return "NUMBER(19, 0)";
     }
 
     function whereInBulkEmpty() {

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -347,6 +347,41 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function whereInBulkStrings() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""status"" IN (SELECT CAST(""value"" AS TEXT) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[""active"",""pending""]" ]
+        };
+    }
+
+    function whereInBulkMixed() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""externalId"" IN (SELECT CAST(""value"" AS TEXT) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[1,""two""]" ]
+        };
+    }
+
+    function whereInBulkBooleans() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""active"" IN (SELECT CAST(""value"" AS BOOLEAN) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[true,false]" ]
+        };
+    }
+
+    function whereInBulkBigInt() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS BIGINT) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[1,2]" ]
+        };
+    }
+
+    function whereInBulkExplicitType() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS BIGINT) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
     function orWhereInBulk() {
         return {
             sql: "SELECT * FROM ""users"" WHERE ""active"" = ? OR ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -340,6 +340,35 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function orWhereInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""active"" = ? OR ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ 1, "[1,2,3]" ]
+        };
+    }
+
+    function whereNotInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" NOT IN (SELECT CAST(""value"" AS INTEGER) FROM JSONB_ARRAY_ELEMENTS_TEXT(CAST(? AS JSONB)) AS ""qb_bulk_values""(""value""))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return {
             sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)",

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -390,6 +390,35 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM ""users"" WHERE ""id"" IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function orWhereInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""active"" = ? OR ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",
+            bindings: [ 1, "[1,2,3]" ]
+        };
+    }
+
+    function whereNotInBulk() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" NOT IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM ""users"" WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return {
             sql: "SELECT * FROM ""users"" WHERE ""email"" = ? OR ""id"" IN (?, ?, ?)",

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -397,6 +397,45 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function whereInBulkStrings() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""status"" IN (SELECT CAST(""value"" AS TEXT) FROM JSON_EACH(?))",
+            bindings: [ "[""active"",""pending""]" ]
+        };
+    }
+
+    function whereInBulkMixed() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""externalId"" IN (SELECT CAST(""value"" AS TEXT) FROM JSON_EACH(?))",
+            bindings: [ "[1,""two""]" ]
+        };
+    }
+
+    function whereInBulkBooleans() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""active"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",
+            bindings: [ "[true,false]" ]
+        };
+    }
+
+    function whereInBulkBigInt() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",
+            bindings: [ "[1,2]" ]
+        };
+    }
+
+    function whereInBulkExplicitType() {
+        return {
+            sql: "SELECT * FROM ""users"" WHERE ""id"" IN (SELECT CAST(""value"" AS BIGINT) FROM JSON_EACH(?))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function bulkTimestampSqlType() {
+        return "TEXT";
+    }
+
     function orWhereInBulk() {
         return {
             sql: "SELECT * FROM ""users"" WHERE ""active"" = ? OR ""id"" IN (SELECT CAST(""value"" AS INTEGER) FROM JSON_EACH(?))",

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -334,6 +334,35 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         return { sql: "SELECT * FROM [users] WHERE [id] IN (?, ?, ?)", bindings: [ 1, 2, 3 ] };
     }
 
+    function whereInBulk() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [id] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] INTEGER '$'))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function orWhereInBulk() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [active] = ? OR [id] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] INTEGER '$'))",
+            bindings: [ 1, "[1,2,3]" ]
+        };
+    }
+
+    function whereNotInBulk() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [id] NOT IN (SELECT [value] FROM OPENJSON(?) WITH ([value] INTEGER '$'))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function whereInBulkEmpty() {
+        return "SELECT * FROM [users] WHERE 0 = 1";
+    }
+
+    function whereNotInBulkEmpty() {
+        return "SELECT * FROM [users] WHERE 1 = 1";
+    }
+
     function orWhereIn() {
         return { sql: "SELECT * FROM [users] WHERE [email] = ? OR [id] IN (?, ?, ?)", bindings: [ "foo", 1, 2, 3 ] };
     }

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -341,6 +341,45 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function whereInBulkStrings() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [status] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] NVARCHAR(MAX) '$'))",
+            bindings: [ "[""active"",""pending""]" ]
+        };
+    }
+
+    function whereInBulkMixed() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [externalId] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] NVARCHAR(MAX) '$'))",
+            bindings: [ "[1,""two""]" ]
+        };
+    }
+
+    function whereInBulkBooleans() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [active] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] BIT '$'))",
+            bindings: [ "[1,0]" ]
+        };
+    }
+
+    function whereInBulkBigInt() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [id] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] BIGINT '$'))",
+            bindings: [ "[1,2]" ]
+        };
+    }
+
+    function whereInBulkExplicitType() {
+        return {
+            sql: "SELECT * FROM [users] WHERE [id] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] BIGINT '$'))",
+            bindings: [ "[1,2,3]" ]
+        };
+    }
+
+    function bulkTimestampSqlType() {
+        return "DATETIME2";
+    }
+
     function orWhereInBulk() {
         return {
             sql: "SELECT * FROM [users] WHERE [active] = ? OR [id] IN (SELECT [value] FROM OPENJSON(?) WITH ([value] INTEGER '$'))",


### PR DESCRIPTION
## Summary

- add `whereInBulk` and `whereNotInBulk`, including dynamic `andWhere...` and `orWhere...` shortcuts
- serialize bulk values into one `LONGVARCHAR` binding
- infer a common SQL type from raw values or matching typed query parameters
- translate inferred types to native SQL Server, PostgreSQL, MySQL/MariaDB, Oracle, and SQLite types
- preserve an explicit third-argument `sqlType` override for database-specific or precision-sensitive columns
- keep Derby explicitly unsupported for non-empty bulk collections
- document database feature and version requirements

## Why

Large `whereIn` collections create one database parameter per value. SQL Server rejects statements above its 2,100-parameter limit. `whereInBulk` provides an explicit opt-in path that uses one serialized binding, so regular `whereIn` behavior and performance remain unchanged.

Refs #109.

## Validation

- added the inference contract and per-grammar expectations first and confirmed they failed before implementation
- `box testbox run` on Lucee 6: 2,762 passed, 0 failed, 3 skipped
- GitHub Actions: all 18 checks passed, including native BoxLang with full-null on and off
- `box run-script format:check`
- `git diff --check`
- executed the emitted SQLite `JSON_EACH` form directly against SQLite
