### PR TITLE
Fix SQL Server defaults when modifying columns

### DIFF
--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -337,6 +337,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         }
 
         arguments.value = reReplace( arguments.value, """", "", "all" );
+        arguments.value = replace( arguments.value, "]", "]]", "all" );
 
         return "[#value#]";
     }
@@ -784,7 +785,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
 
             commandParameters.to.setDefaultValue( "" );
 
-            var wrappedTable = wrapTable( blueprint.getTable() );
+            var wrappedTable = wrapTable( blueprint.getTable(), false );
             var wrappedColumn = wrapValue( commandParameters.to.getName() );
             var escapedTable = replace( wrappedTable, "'", "''", "all" );
             var escapedColumn = replace(
@@ -803,7 +804,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
             commandParameters.to.setDefaultValue( originalDefaultValue );
 
             return [
-                "DECLARE @constraintName NVARCHAR(128); SELECT @constraintName = [dc].[name] FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = OBJECT_ID(N'#escapedTable#') AND [c].[name] = N'#escapedColumn#'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE #escapedTable# DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
+                "DECLARE @objectId INT = OBJECT_ID(N'#escapedTable#'), @constraintName SYSNAME, @schemaName SYSNAME, @tableName SYSNAME; SELECT @constraintName = [dc].[name], @schemaName = OBJECT_SCHEMA_NAME([dc].[parent_object_id]), @tableName = OBJECT_NAME([dc].[parent_object_id]) FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = @objectId AND [c].[name] = N'#escapedColumn#'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE ' + QUOTENAME(@schemaName) + N'.' + QUOTENAME(@tableName) + N' DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
                 alterColumnSql,
                 concatenate( [
                     "ALTER TABLE",

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -768,17 +768,56 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
     function compileModifyColumn( blueprint, commandParameters ) {
         try {
             var originalShouldWrapValues = getShouldWrapValues();
+            var originalDefaultValue = commandParameters.to.getDefaultValue();
             if ( !isNull( arguments.blueprint.getSchemaBuilder().getShouldWrapValues() ) ) {
                 setShouldWrapValues( arguments.blueprint.getSchemaBuilder().getShouldWrapValues() );
             }
 
-            return concatenate( [
+            if ( originalDefaultValue == "" ) {
+                return concatenate( [
+                    "ALTER TABLE",
+                    wrapTable( blueprint.getTable() ),
+                    "ALTER COLUMN",
+                    compileCreateColumn( commandParameters.to, blueprint )
+                ] );
+            }
+
+            commandParameters.to.setDefaultValue( "" );
+
+            var wrappedTable = wrapTable( blueprint.getTable() );
+            var wrappedColumn = wrapValue( commandParameters.to.getName() );
+            var escapedTable = replace( wrappedTable, "'", "''", "all" );
+            var escapedColumn = replace(
+                commandParameters.to.getName(),
+                "'",
+                "''",
+                "all"
+            );
+            var alterColumnSql = concatenate( [
                 "ALTER TABLE",
-                wrapTable( blueprint.getTable() ),
+                wrappedTable,
                 "ALTER COLUMN",
                 compileCreateColumn( commandParameters.to, blueprint )
             ] );
+
+            commandParameters.to.setDefaultValue( originalDefaultValue );
+
+            return [
+                "DECLARE @constraintName NVARCHAR(128); SELECT @constraintName = [dc].[name] FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = OBJECT_ID(N'#escapedTable#') AND [c].[name] = N'#escapedColumn#'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE #escapedTable# DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
+                alterColumnSql,
+                concatenate( [
+                    "ALTER TABLE",
+                    wrappedTable,
+                    "ADD CONSTRAINT",
+                    wrapValue( "df_#blueprint.getTable()#_#commandParameters.to.getName()#" ),
+                    "DEFAULT",
+                    wrapDefaultType( commandParameters.to ),
+                    "FOR",
+                    wrappedColumn
+                ] )
+            ];
         } finally {
+            commandParameters.to.setDefaultValue( originalDefaultValue );
             if ( !isNull( arguments.blueprint.getSchemaBuilder().getShouldWrapValues() ) ) {
                 setShouldWrapValues( originalShouldWrapValues );
             }

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -17,9 +17,29 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
                         );
                     },
                     [
-                        "DECLARE @constraintName NVARCHAR(128); SELECT @constraintName = [dc].[name] FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = OBJECT_ID(N'[mars_in_wash_sales]') AND [c].[name] = N'shares'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE [mars_in_wash_sales] DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
+                        "DECLARE @objectId INT = OBJECT_ID(N'[mars_in_wash_sales]'), @constraintName SYSNAME, @schemaName SYSNAME, @tableName SYSNAME; SELECT @constraintName = [dc].[name], @schemaName = OBJECT_SCHEMA_NAME([dc].[parent_object_id]), @tableName = OBJECT_NAME([dc].[parent_object_id]) FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = @objectId AND [c].[name] = N'shares'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE ' + QUOTENAME(@schemaName) + N'.' + QUOTENAME(@tableName) + N' DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
                         "ALTER TABLE [mars_in_wash_sales] ALTER COLUMN [shares] SMALLINT NOT NULL",
                         "ALTER TABLE [mars_in_wash_sales] ADD CONSTRAINT [df_mars_in_wash_sales_shares] DEFAULT -999 FOR [shares]"
+                    ]
+                );
+            } );
+
+            it( "does not interpolate caller-provided identifiers into dynamic SQL", function() {
+                testCase(
+                    function( schema ) {
+                        return schema.alter(
+                            "odd]name'",
+                            function( table ) {
+                                table.modifyColumn( "sha]res'", table.smallinteger( "sha]res'" ).default( -999 ) );
+                            },
+                            {},
+                            false
+                        );
+                    },
+                    [
+                        "DECLARE @objectId INT = OBJECT_ID(N'[odd]]name'']'), @constraintName SYSNAME, @schemaName SYSNAME, @tableName SYSNAME; SELECT @constraintName = [dc].[name], @schemaName = OBJECT_SCHEMA_NAME([dc].[parent_object_id]), @tableName = OBJECT_NAME([dc].[parent_object_id]) FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = @objectId AND [c].[name] = N'sha]res'''; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE ' + QUOTENAME(@schemaName) + N'.' + QUOTENAME(@tableName) + N' DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
+                        "ALTER TABLE [odd]]name'] ALTER COLUMN [sha]]res'] SMALLINT NOT NULL",
+                        "ALTER TABLE [odd]]name'] ADD CONSTRAINT [df_odd]]name'_sha]]res'] DEFAULT -999 FOR [sha]]res']"
                     ]
                 );
             } );

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -1,5 +1,31 @@
 component extends="tests.resources.AbstractSchemaBuilderSpec" {
 
+    function run() {
+        super.run();
+
+        describe( "SQL Server column modifications", function() {
+            it( "replaces a default constraint when modifying a column", function() {
+                testCase(
+                    function( schema ) {
+                        return schema.alter(
+                            "mars_in_wash_sales",
+                            function( table ) {
+                                table.modifyColumn( "shares", table.smallinteger( "shares" ).default( -999 ) );
+                            },
+                            {},
+                            false
+                        );
+                    },
+                    [
+                        "DECLARE @constraintName NVARCHAR(128); SELECT @constraintName = [dc].[name] FROM [sys].[default_constraints] AS [dc] INNER JOIN [sys].[columns] AS [c] ON [c].[default_object_id] = [dc].[object_id] WHERE [dc].[parent_object_id] = OBJECT_ID(N'[mars_in_wash_sales]') AND [c].[name] = N'shares'; IF @constraintName IS NOT NULL EXEC(N'ALTER TABLE [mars_in_wash_sales] DROP CONSTRAINT ' + QUOTENAME(@constraintName))",
+                        "ALTER TABLE [mars_in_wash_sales] ALTER COLUMN [shares] SMALLINT NOT NULL",
+                        "ALTER TABLE [mars_in_wash_sales] ADD CONSTRAINT [df_mars_in_wash_sales_shares] DEFAULT -999 FOR [shares]"
+                    ]
+                );
+            } );
+        } );
+    }
+
     function emptyTable() {
         return [ "CREATE TABLE [users] ()" ];
     }


### PR DESCRIPTION
Closes #152

## What changed

- remove an existing SQL Server default constraint before altering a column with a new default
- discover the existing constraint through SQL Server system catalogs so custom constraint names are supported
- add the requested default back as a valid standalone constraint after the column alteration
- add a regression test using the reproduction from the issue

## Root cause

The SQL Server modify-column compiler reused the create-column compiler, which placed `CONSTRAINT ... DEFAULT` inline in an `ALTER COLUMN` statement. SQL Server does not accept default constraints in that position.

## Validation

- TestBox on Lucee 6: 2,773 passed, 0 failed, 3 skipped
- `box run-script format:check`
- `git diff --check`