### PR TITLE
Add parameter-aware bulk inserts

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -934,6 +934,23 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     /**
+     * Whether this grammar provides a native bulk insert strategy.
+     */
+    public boolean function supportsBulkInsert() {
+        return false;
+    }
+
+    /**
+     * Compile a native bulk insert statement.
+     *
+     * @query The Builder instance.
+     * @columns The columns and resolved SQL types to insert.
+     */
+    public string function compileBulkInsert( required any query, required array columns ) {
+        throw( type = "UnsupportedOperation", message = "This grammar does not support native bulk inserts." );
+    }
+
+    /**
      * Compile a Builder's query into an insert string ignoring duplicate key values.
      *
      * @qb The Builder instance.

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -7,12 +7,6 @@
 component displayname="Grammar" accessors="true" singleton {
 
     /**
-     * The maximum number of parameters supported in a single statement.
-     * A value of zero indicates no grammar-specific limit.
-     */
-    this.parameterLimit = 0;
-
-    /**
      * ColdBox Interceptor Service to announce pre- and post- interception points
      */
     property name="interceptorService" inject="box:interceptorService";
@@ -37,6 +31,12 @@ component displayname="Grammar" accessors="true" singleton {
      * Table alias operator for the grammar.
      */
     property name="tableAliasOperator" type="string" default=" AS ";
+
+    /**
+     * The maximum number of parameters supported in a single statement.
+     * A value of zero indicates no grammar-specific limit.
+     */
+    this.parameterLimit = 0;
 
     /**
      * The different components of a select statement in the order of compilation.

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -941,6 +941,53 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     /**
+     * Prepare values and column metadata for a grammar's native bulk insert compiler.
+     *
+     * @query The Builder instance.
+     * @values The rows to insert.
+     * @sqlTypes Explicit SQL types keyed by column name.
+     */
+    public struct function prepareBulkInsert( required any query, required array values, required struct sqlTypes ) {
+        var builder = arguments.query;
+        var columns = arguments.values[ 1 ]
+            .keyArray()
+            .map( function( column ) {
+                var formatted = listLast( builder.applyColumnFormatter( column ), "." );
+                return { "original": column, "formatted": { "type": "simple", "value": formatted } };
+            } );
+        columns.sort( ( a, b ) => compareNoCase( a.formatted.value, b.formatted.value ) );
+
+        arguments.values.each( function( row ) {
+            columns.each( function( column ) {
+                if (
+                    row.keyExists( column.original ) &&
+                    !isNull( row[ column.original ] ) &&
+                    getUtils().isExpression( row[ column.original ] )
+                ) {
+                    throw( type = "InvalidBulkValue", message = "Bulk insert values cannot contain SQL expressions." );
+                }
+            } );
+        } );
+
+        return prepareBulkInsertValues( arguments.values, columns, arguments.sqlTypes );
+    }
+
+    /**
+     * Prepare database-specific values and metadata for a native bulk insert.
+     *
+     * @values The rows to insert.
+     * @columns The normalized columns to insert.
+     * @sqlTypes Explicit SQL types keyed by column name.
+     */
+    public struct function prepareBulkInsertValues(
+        required array values,
+        required array columns,
+        required struct sqlTypes
+    ) {
+        throw( type = "UnsupportedOperation", message = "This grammar does not support native bulk inserts." );
+    }
+
+    /**
      * Compile a native bulk insert statement.
      *
      * @query The Builder instance.

--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -7,6 +7,12 @@
 component displayname="Grammar" accessors="true" singleton {
 
     /**
+     * The maximum number of parameters supported in a single statement.
+     * A value of zero indicates no grammar-specific limit.
+     */
+    this.parameterLimit = 0;
+
+    /**
      * ColdBox Interceptor Service to announce pre- and post- interception points
      */
     property name="interceptorService" inject="box:interceptorService";

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -1,5 +1,50 @@
 component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
 
+    public boolean function supportsBulkInsert() {
+        return true;
+    }
+
+    public string function compileBulkInsert( required any query, required array columns ) {
+        try {
+            var originalShouldWrapValues = getShouldWrapValues();
+            if ( !isNull( arguments.query.getShouldWrapValues() ) ) {
+                setShouldWrapValues( arguments.query.getShouldWrapValues() );
+            }
+
+            var columnsString = arguments.columns.map( ( column ) => wrapColumn( column.formatted ) ).toList( ", " );
+            var returningColumns = arguments.query
+                .getReturning()
+                .map( function( column ) {
+                    if ( column.type == "raw" ) {
+                        return trim( column.getSQL() );
+                    }
+                    if ( listLen( column.value, "." ) > 1 ) {
+                        return column.value;
+                    }
+                    return "INSERTED." & wrapColumn( column );
+                } )
+                .toList( ", " );
+            var returningClause = returningColumns != "" ? " OUTPUT #returningColumns#" : "";
+            var withColumns = arguments.columns
+                .map( function( column ) {
+                    var escapedPath = replace(
+                        replace( column.original, "\", "\\", "all" ),
+                        """",
+                        "\""",
+                        "all"
+                    );
+                    return "#wrapColumn( column.formatted )# #column.bulkSqlType# '$.""#escapedPath#""'";
+                } )
+                .toList( ", " );
+
+            return "INSERT INTO #wrapTable( query.getTableName() )# (#columnsString#)#returningClause# SELECT #columnsString# FROM OPENJSON(?) WITH (#withColumns#)";
+        } finally {
+            if ( !isNull( arguments.query.getShouldWrapValues() ) ) {
+                setShouldWrapValues( originalShouldWrapValues );
+            }
+        }
+    }
+
     public string function compileWhereInBulkValues( required string sqlType ) {
         return "SELECT [value] FROM OPENJSON(?) WITH ([value] #arguments.sqlType# '$')";
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -4,6 +4,57 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return true;
     }
 
+    public struct function prepareBulkInsertValues(
+        required array values,
+        required array columns,
+        required struct sqlTypes
+    ) {
+        var grammar = this;
+        var normalizedColumns = arguments.columns;
+        var serializedValues = arguments.values.map( function( row ) {
+            var serializedRow = {};
+            normalizedColumns.each( function( column ) {
+                if ( !row.keyExists( column.original ) || isNull( row[ column.original ] ) ) {
+                    serializedRow[ column.original ] = javacast( "null", "" );
+                    return;
+                }
+                var binding = getUtils().extractBinding( row[ column.original ], grammar );
+                serializedRow[ column.original ] = binding.null ? javacast( "null", "" ) : binding.value;
+            } );
+            return serializedRow;
+        } );
+
+        var bulkValues = arguments.values;
+        var explicitSqlTypes = arguments.sqlTypes;
+        normalizedColumns.each( function( column ) {
+            var columnValues = bulkValues.map( function( row ) {
+                return row.keyExists( column.original ) ? row[ column.original ] : javacast( "null", "" );
+            } );
+            var sqlType = explicitSqlTypes.keyExists( column.original )
+             ? explicitSqlTypes[ column.original ]
+             : resolveWhereInBulkSqlType( getUtils().inferSqlType( columnValues, grammar ) );
+            sqlType = trim( sqlType );
+            if (
+                sqlType == "" ||
+                !reFindNoCase(
+                    "^[a-z][a-z0-9_]*(?:\s+[a-z][a-z0-9_]*)*(?:\s*\(\s*(?:max|\d+)(?:\s*,\s*\d+)?\s*\))?$",
+                    sqlType
+                )
+            ) {
+                throw( type = "InvalidSQLType", message = "Invalid SQL type [#sqlType#] for a bulk insert." );
+            }
+            column.bulkSqlType = sqlType;
+        } );
+
+        return {
+            "columns": normalizedColumns,
+            "binding": getUtils().extractBinding(
+                { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
+                grammar
+            )
+        };
+    }
+
     public string function compileBulkInsert( required any query, required array columns ) {
         try {
             var originalShouldWrapValues = getShouldWrapValues();

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3715,7 +3715,7 @@ component displayname="QueryBuilder" accessors="true" {
             var batch = arguments.values.slice( offset, batchSize );
 
             if ( getGrammar().supportsBulkInsert() ) {
-                var bulkInsert = prepareBulkInsert( batch, arguments.sqlTypes );
+                var bulkInsert = getGrammar().prepareBulkInsert( this, batch, arguments.sqlTypes );
                 addBindings( [ bulkInsert.binding ], "insert" );
                 var sql = getGrammar().compileBulkInsert( this, bulkInsert.columns );
                 if ( arguments.toSql ) {
@@ -3733,65 +3733,6 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         return results;
-    }
-
-    /**
-     * Prepares a batch for a grammar's native bulk insert compiler.
-     */
-    private struct function prepareBulkInsert( required array values, required struct sqlTypes ) {
-        var columns = arguments.values[ 1 ]
-            .keyArray()
-            .map( function( column ) {
-                var formatted = listLast( applyColumnFormatter( column ), "." );
-                return { "original": column, "formatted": mapToColumnType( formatted ) };
-            } );
-        columns.sort( ( a, b ) => compareNoCase( a.formatted.value, b.formatted.value ) );
-
-        var serializedValues = arguments.values.map( function( row ) {
-            var serializedRow = {};
-            columns.each( function( column ) {
-                if ( !row.keyExists( column.original ) || isNull( row[ column.original ] ) ) {
-                    serializedRow[ column.original ] = javacast( "null", "" );
-                    return;
-                }
-                if ( getUtils().isExpression( row[ column.original ] ) ) {
-                    throw( type = "InvalidBulkValue", message = "Bulk insert values cannot contain SQL expressions." );
-                }
-                var binding = getUtils().extractBinding( row[ column.original ], variables.grammar );
-                serializedRow[ column.original ] = binding.null ? javacast( "null", "" ) : binding.value;
-            } );
-            return serializedRow;
-        } );
-
-        var bulkValues = arguments.values;
-        var explicitSqlTypes = arguments.sqlTypes;
-        columns.each( function( column ) {
-            var columnValues = bulkValues.map( function( row ) {
-                return row.keyExists( column.original ) ? row[ column.original ] : javacast( "null", "" );
-            } );
-            var sqlType = explicitSqlTypes.keyExists( column.original )
-             ? explicitSqlTypes[ column.original ]
-             : getGrammar().resolveWhereInBulkSqlType( getUtils().inferSqlType( columnValues, variables.grammar ) );
-            sqlType = trim( sqlType );
-            if (
-                sqlType == "" ||
-                !reFindNoCase(
-                    "^[a-z][a-z0-9_]*(?:\s+[a-z][a-z0-9_]*)*(?:\s*\(\s*(?:max|\d+)(?:\s*,\s*\d+)?\s*\))?$",
-                    sqlType
-                )
-            ) {
-                throw( type = "InvalidSQLType", message = "Invalid SQL type [#sqlType#] for a bulk insert." );
-            }
-            column.bulkSqlType = sqlType;
-        } );
-
-        return {
-            "columns": columns,
-            "binding": getUtils().extractBinding(
-                { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
-                variables.grammar
-            )
-        };
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3715,7 +3715,9 @@ component displayname="QueryBuilder" accessors="true" {
             var batch = arguments.values.slice( offset, batchSize );
 
             if ( getGrammar().supportsBulkInsert() ) {
-                var sql = compileNativeBulkInsert( batch, arguments.sqlTypes );
+                var bulkInsert = prepareBulkInsert( batch, arguments.sqlTypes );
+                addBindings( [ bulkInsert.binding ], "insert" );
+                var sql = getGrammar().compileBulkInsert( this, bulkInsert.columns );
                 if ( arguments.toSql ) {
                     results.append( sql );
                 } else {
@@ -3736,7 +3738,7 @@ component displayname="QueryBuilder" accessors="true" {
     /**
      * Prepares a batch for a grammar's native bulk insert compiler.
      */
-    private string function compileNativeBulkInsert( required array values, required struct sqlTypes ) {
+    private struct function prepareBulkInsert( required array values, required struct sqlTypes ) {
         var columns = arguments.values[ 1 ]
             .keyArray()
             .map( function( column ) {
@@ -3783,17 +3785,13 @@ component displayname="QueryBuilder" accessors="true" {
             column.bulkSqlType = sqlType;
         } );
 
-        addBindings(
-            [
-                getUtils().extractBinding(
-                    { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
-                    variables.grammar
-                )
-            ],
-            "insert"
-        );
-
-        return getGrammar().compileBulkInsert( this, columns );
+        return {
+            "columns": columns,
+            "binding": getUtils().extractBinding(
+                { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
+                variables.grammar
+            )
+        };
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3674,12 +3674,12 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
-     * Inserts a large set of rows using parameter-aware batches.
-     * Grammars may provide a more efficient bulk strategy in the future without
-     * changing this public API.
+     * Inserts a large set of rows using a grammar's native bulk strategy when available,
+     * falling back to parameter-aware batches otherwise.
      *
      * @values An array of structs to insert in to the table.
-     * @chunkSize The preferred number of rows per batch. A value of zero uses the largest safe batch for the grammar. Default: 0.
+     * @sqlTypes SQL types keyed by column name. Types are inferred for columns not provided.
+     * @chunkSize The preferred number of rows per batch. A non-positive value uses all rows, subject to grammar parameter limits. Default: -1.
      * @options Any options to pass to `queryExecute`. Default: {}.
      * @toSql If true, returns the raw SQL strings instead of running the queries. Useful for debugging. Default: false.
      *
@@ -3687,16 +3687,13 @@ component displayname="QueryBuilder" accessors="true" {
      */
     public array function insertBulk(
         required array values,
-        numeric chunkSize = 0,
+        struct sqlTypes = {},
+        numeric chunkSize = -1,
         struct options = {},
         boolean toSql = false
     ) {
         if ( arguments.values.isEmpty() ) {
             return [];
-        }
-
-        if ( arguments.chunkSize < 0 ) {
-            throw( type = "InvalidChunkSize", message = "The insertBulk chunkSize must be zero or greater." );
         }
 
         var columnCount = arguments.values[ 1 ].count();
@@ -3705,7 +3702,7 @@ component displayname="QueryBuilder" accessors="true" {
         }
 
         var safeChunkSize = arguments.values.len();
-        if ( getGrammar().parameterLimit > 0 ) {
+        if ( !getGrammar().supportsBulkInsert() && getGrammar().parameterLimit > 0 ) {
             safeChunkSize = max( 1, floor( getGrammar().parameterLimit / columnCount ) );
         }
         if ( arguments.chunkSize > 0 ) {
@@ -3715,17 +3712,88 @@ component displayname="QueryBuilder" accessors="true" {
         var results = [];
         for ( var offset = 1; offset <= arguments.values.len(); offset += safeChunkSize ) {
             var batchSize = min( safeChunkSize, arguments.values.len() - offset + 1 );
-            var batchQuery = clone();
-            results.append(
-                batchQuery.insert(
-                    values = arguments.values.slice( offset, batchSize ),
-                    options = arguments.options,
-                    toSql = arguments.toSql
-                )
-            );
+            var batch = arguments.values.slice( offset, batchSize );
+
+            if ( getGrammar().supportsBulkInsert() ) {
+                var sql = compileNativeBulkInsert( batch, arguments.sqlTypes );
+                if ( arguments.toSql ) {
+                    results.append( sql );
+                } else {
+                    results.append( runQuery( sql, arguments.options, "result" ) );
+                    clearBindings( only = [ "insert" ] );
+                }
+            } else {
+                var batchQuery = clone();
+                results.append(
+                    batchQuery.insert( values = batch, options = arguments.options, toSql = arguments.toSql )
+                );
+            }
         }
 
         return results;
+    }
+
+    /**
+     * Prepares a batch for a grammar's native bulk insert compiler.
+     */
+    private string function compileNativeBulkInsert( required array values, required struct sqlTypes ) {
+        var columns = arguments.values[ 1 ]
+            .keyArray()
+            .map( function( column ) {
+                var formatted = listLast( applyColumnFormatter( column ), "." );
+                return { "original": column, "formatted": mapToColumnType( formatted ) };
+            } );
+        columns.sort( ( a, b ) => compareNoCase( a.formatted.value, b.formatted.value ) );
+
+        var serializedValues = arguments.values.map( function( row ) {
+            var serializedRow = {};
+            columns.each( function( column ) {
+                if ( !row.keyExists( column.original ) || isNull( row[ column.original ] ) ) {
+                    serializedRow[ column.original ] = javacast( "null", "" );
+                    return;
+                }
+                if ( getUtils().isExpression( row[ column.original ] ) ) {
+                    throw( type = "InvalidBulkValue", message = "Bulk insert values cannot contain SQL expressions." );
+                }
+                var binding = getUtils().extractBinding( row[ column.original ], variables.grammar );
+                serializedRow[ column.original ] = binding.null ? javacast( "null", "" ) : binding.value;
+            } );
+            return serializedRow;
+        } );
+
+        var bulkValues = arguments.values;
+        var explicitSqlTypes = arguments.sqlTypes;
+        columns.each( function( column ) {
+            var columnValues = bulkValues.map( function( row ) {
+                return row.keyExists( column.original ) ? row[ column.original ] : javacast( "null", "" );
+            } );
+            var sqlType = explicitSqlTypes.keyExists( column.original )
+             ? explicitSqlTypes[ column.original ]
+             : getGrammar().resolveWhereInBulkSqlType( getUtils().inferSqlType( columnValues, variables.grammar ) );
+            sqlType = trim( sqlType );
+            if (
+                sqlType == "" ||
+                !reFindNoCase(
+                    "^[a-z][a-z0-9_]*(?:\s+[a-z][a-z0-9_]*)*(?:\s*\(\s*(?:max|\d+)(?:\s*,\s*\d+)?\s*\))?$",
+                    sqlType
+                )
+            ) {
+                throw( type = "InvalidSQLType", message = "Invalid SQL type [#sqlType#] for a bulk insert." );
+            }
+            column.bulkSqlType = sqlType;
+        } );
+
+        addBindings(
+            [
+                getUtils().extractBinding(
+                    { value: serializeJSON( serializedValues ), cfsqltype: "LONGVARCHAR" },
+                    variables.grammar
+                )
+            ],
+            "insert"
+        );
+
+        return getGrammar().compileBulkInsert( this, columns );
     }
 
     /**

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3679,7 +3679,7 @@ component displayname="QueryBuilder" accessors="true" {
      *
      * @values An array of structs to insert in to the table.
      * @sqlTypes SQL types keyed by column name. Types are inferred for columns not provided.
-     * @chunkSize The preferred number of rows per batch. A non-positive value uses all rows, subject to grammar parameter limits. Default: -1.
+     * @chunkSize The preferred number of rows per batch. A non-positive value uses all rows, subject to grammar parameter limits. Default: 0.
      * @options Any options to pass to `queryExecute`. Default: {}.
      * @toSql If true, returns the raw SQL strings instead of running the queries. Useful for debugging. Default: false.
      *
@@ -3688,7 +3688,7 @@ component displayname="QueryBuilder" accessors="true" {
     public array function insertBulk(
         required array values,
         struct sqlTypes = {},
-        numeric chunkSize = -1,
+        numeric chunkSize = 0,
         struct options = {},
         boolean toSql = false
     ) {

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3674,6 +3674,61 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
     /**
+     * Inserts a large set of rows using parameter-aware batches.
+     * Grammars may provide a more efficient bulk strategy in the future without
+     * changing this public API.
+     *
+     * @values An array of structs to insert in to the table.
+     * @chunkSize The preferred number of rows per batch. A value of zero uses the largest safe batch for the grammar. Default: 0.
+     * @options Any options to pass to `queryExecute`. Default: {}.
+     * @toSql If true, returns the raw SQL strings instead of running the queries. Useful for debugging. Default: false.
+     *
+     * @return array
+     */
+    public array function insertBulk(
+        required array values,
+        numeric chunkSize = 0,
+        struct options = {},
+        boolean toSql = false
+    ) {
+        if ( arguments.values.isEmpty() ) {
+            return [];
+        }
+
+        if ( arguments.chunkSize < 0 ) {
+            throw( type = "InvalidChunkSize", message = "The insertBulk chunkSize must be zero or greater." );
+        }
+
+        var columnCount = arguments.values[ 1 ].count();
+        if ( columnCount == 0 ) {
+            throw( type = "InvalidSQLType", message = "Please pass structs with at least one column to insertBulk." );
+        }
+
+        var safeChunkSize = arguments.values.len();
+        if ( getGrammar().parameterLimit > 0 ) {
+            safeChunkSize = max( 1, floor( getGrammar().parameterLimit / columnCount ) );
+        }
+        if ( arguments.chunkSize > 0 ) {
+            safeChunkSize = min( safeChunkSize, arguments.chunkSize );
+        }
+
+        var results = [];
+        for ( var offset = 1; offset <= arguments.values.len(); offset += safeChunkSize ) {
+            var batchSize = min( safeChunkSize, arguments.values.len() - offset + 1 );
+            var batchQuery = clone();
+            results.append(
+                batchQuery.insert(
+                    values = arguments.values.slice( offset, batchSize ),
+                    options = arguments.options,
+                    toSql = arguments.toSql
+                )
+            );
+        }
+
+        return results;
+    }
+
+    /**
      * Inserts data into a table based off of a query.
      * This call must come after setting the query's table using `from` or `table`.
      *

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -1536,6 +1536,50 @@ component extends="testbox.system.BaseSpec" {
                 expect( sql ).toBe( sqlAgain );
             } );
         } );
+
+        describe( "bulk inserts", function() {
+            it( "inserts values in explicit batches", function() {
+                var sql = getBuilder()
+                    .from( "users" )
+                    .insertBulk(
+                        values = [
+                            { "email": "one@example.com" },
+                            { "email": "two@example.com" },
+                            { "email": "three@example.com" }
+                        ],
+                        chunkSize = 2,
+                        toSql = true
+                    );
+
+                expect( sql ).toBe( [ "INSERT INTO ""users"" (""email"") VALUES (?), (?)", "INSERT INTO ""users"" (""email"") VALUES (?)" ] );
+            } );
+
+            it( "caps batches using the grammar parameter limit", function() {
+                var builder = getBuilder();
+                builder.getGrammar().parameterLimit = 4;
+
+                var sql = builder
+                    .from( "users" )
+                    .insertBulk(
+                        values = [
+                            { "email": "one@example.com", "name": "One" },
+                            { "email": "two@example.com", "name": "Two" },
+                            { "email": "three@example.com", "name": "Three" }
+                        ],
+                        chunkSize = 100,
+                        toSql = true
+                    );
+
+                expect( sql ).toBe( [
+                    "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?), (?, ?)",
+                    "INSERT INTO ""users"" (""email"", ""name"") VALUES (?, ?)"
+                ] );
+            } );
+
+            it( "returns an empty array for no values", function() {
+                expect( getBuilder().from( "users" ).insertBulk( values = [], toSql = true ) ).toBe( [] );
+            } );
+        } );
     }
 
     private function getBuilder() {

--- a/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
+++ b/tests/specs/Query/Abstract/QueryExecutionSpec.cfc
@@ -1579,6 +1579,18 @@ component extends="testbox.system.BaseSpec" {
             it( "returns an empty array for no values", function() {
                 expect( getBuilder().from( "users" ).insertBulk( values = [], toSql = true ) ).toBe( [] );
             } );
+
+            it( "uses a non-positive chunk size to insert all rows", function() {
+                var sql = getBuilder()
+                    .from( "users" )
+                    .insertBulk(
+                        values = [ { "email": "one@example.com" }, { "email": "two@example.com" } ],
+                        chunkSize = -1,
+                        toSql = true
+                    );
+
+                expect( sql ).toBe( [ "INSERT INTO ""users"" (""email"") VALUES (?), (?)" ] );
+            } );
         } );
     }
 

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1,5 +1,50 @@
 component extends="tests.resources.AbstractQueryBuilderSpec" {
 
+    function run() {
+        super.run();
+
+        describe( "SQL Server bulk inserts", function() {
+            it( "inserts all rows from one JSON parameter", function() {
+                var builder = getBuilder();
+                var sql = builder
+                    .from( "users" )
+                    .insertBulk( values = [ { "id": 1, "name": "One" }, { "id": 2, "name": "Two" } ], toSql = true );
+
+                expect( sql ).toBe( [
+                    "INSERT INTO [users] ([id], [name]) SELECT [id], [name] FROM OPENJSON(?) WITH ([id] INTEGER '$.""id""', [name] NVARCHAR(MAX) '$.""name""')"
+                ] );
+                expect( builder.getBindings() ).toHaveLength( 1 );
+                expect( deserializeJSON( builder.getBindings()[ 1 ].value ) ).toBe( [ { "id": 1, "name": "One" }, { "id": 2, "name": "Two" } ] );
+            } );
+
+            it( "supports explicit SQL types", function() {
+                var builder = getBuilder();
+                var sql = builder
+                    .from( "measurements" )
+                    .insertBulk(
+                        values = [ { "reading": 1.5 } ],
+                        sqlTypes = { "reading": "DECIMAL(10, 2)" },
+                        toSql = true
+                    );
+
+                expect( sql ).toBe( [
+                    "INSERT INTO [measurements] ([reading]) SELECT [reading] FROM OPENJSON(?) WITH ([reading] DECIMAL(10, 2) '$.""reading""')"
+                ] );
+            } );
+
+            it( "applies returning columns to bulk inserts", function() {
+                var sql = getBuilder()
+                    .from( "users" )
+                    .returning( "id" )
+                    .insertBulk( values = [ { "name": "One" } ], toSql = true );
+
+                expect( sql ).toBe( [
+                    "INSERT INTO [users] ([name]) OUTPUT INSERTED.[id] SELECT [name] FROM OPENJSON(?) WITH ([name] NVARCHAR(MAX) '$.""name""')"
+                ] );
+            } );
+        } );
+    }
+
     function selectAllColumns() {
         return "SELECT * FROM [users]";
     }


### PR DESCRIPTION
Addresses #153

## What changed

- add an `insertBulk()` API for arrays of structs
- use one serialized JSON parameter with `OPENJSON` for SQL Server bulk inserts
- infer SQL Server column types using the same type-resolution foundation as `whereInBulk`, with optional `sqlTypes` overrides
- preserve SQL Server `returning()` support through the `OUTPUT` clause
- use parameter-aware multi-row insert batches as the portable fallback for grammars without a native strategy
- accept a positive `chunkSize` as an explicit cap; consistent with pagination conventions, non-positive values mean all rows subject to fallback grammar parameter limits

## Why

Large multi-row inserts can exceed database parameter limits. SQL Server can avoid that limit entirely by sending the rows as one JSON binding and expanding them into a typed rowset with `OPENJSON`. Other grammars continue to receive safe batching without exposing chunking as the primary API.

## Tests

Tests were added first for explicit fallback batching, grammar-limit enforcement, empty input, the non-positive all-rows convention, SQL Server `OPENJSON`, inferred and explicit SQL types, serialized bindings, and `returning()`.

- TestBox on Lucee 6: 2,779 passed, 0 failed, 3 skipped
- `box run-script format:check`
- `git diff --check`