### PR TITLE
Fix ordered SQL Server UNION branches

### DIFF
--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -146,6 +146,71 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
     }
 
     /**
+     * Compile independently ordered and limited UNION branches as derived queries.
+     * SQL Server requires this shape for ORDER BY to determine each branch's TOP rows.
+     */
+    public string function compileSelect( required QueryBuilder query ) {
+        if ( !shouldCompileOrderedUnionBranches( arguments.query ) ) {
+            return super.compileSelect( arguments.query );
+        }
+
+        try {
+            var originalShouldWrapValues = getShouldWrapValues();
+            if ( !isNull( arguments.query.getShouldWrapValues() ) ) {
+                setShouldWrapValues( arguments.query.getShouldWrapValues() );
+            }
+
+            var commonTables = arguments.query.getCommonTables();
+            var rootQuery = arguments.query.clone();
+            var unions = rootQuery.getUnions();
+            rootQuery.setUnions( [] );
+            rootQuery.setCommonTables( [] );
+
+            var sql = [
+                commonTables.isEmpty() ? "" : compileCommonTables( arguments.query, commonTables ),
+                "SELECT * FROM (#super.compileSelect( rootQuery )#) AS #wrapValue( "qb_union_0" )#"
+            ];
+
+            unions.each( function( union, index ) {
+                if ( union.query.getOrders().len() && !isLimitedQuery( union.query ) ) {
+                    throw(
+                        type = "OrderByNotAllowed",
+                        message = "The ORDER BY clause is not allowed in an unlimited UNION branch.",
+                        detail = "SQL Server only allows an ORDER BY clause in a UNION branch when TOP, OFFSET, or FETCH limits that branch."
+                    );
+                }
+
+                var unionOperator = union.all ? "UNION ALL" : "UNION";
+                sql.append(
+                    "#unionOperator# SELECT * FROM (#compileSelect( union.query )#) AS #wrapValue( "qb_union_#index#" )#"
+                );
+            } );
+
+            return trim( concatenate( sql ) );
+        } finally {
+            if ( !isNull( arguments.query.getShouldWrapValues() ) ) {
+                setShouldWrapValues( originalShouldWrapValues );
+            }
+        }
+    }
+
+    private boolean function shouldCompileOrderedUnionBranches( required QueryBuilder query ) {
+        if ( arguments.query.getUnions().isEmpty() || !isOrderedLimitedQuery( arguments.query ) ) {
+            return false;
+        }
+
+        return arguments.query.getUnions().some( ( union ) => isOrderedLimitedQuery( union.query ) );
+    }
+
+    private boolean function isOrderedLimitedQuery( required QueryBuilder query ) {
+        return arguments.query.getOrders().len() && isLimitedQuery( arguments.query );
+    }
+
+    private boolean function isLimitedQuery( required QueryBuilder query ) {
+        return !isNull( arguments.query.getLimitValue() ) || !isNull( arguments.query.getOffsetValue() );
+    }
+
+    /**
      * The parameter limit for SQL Server grammar.
      */
     this.parameterLimit = 2000;

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -43,6 +43,34 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
                 ] );
             } );
         } );
+
+        describe( "SQL Server ordered unions", function() {
+            it( "can limit independently ordered union branches", function() {
+                var sql = getBuilder()
+                    .select( "*" )
+                    .fromSub( "t", function( q ) {
+                        q.select( "id, name, modifiedDate" )
+                            .selectRaw( "'Page' AS typeName" )
+                            .from( "page" )
+                            .orderBy( "modifiedDate", "DESC" )
+                            .limit( 5 )
+                            .unionAll( function( q ) {
+                                q.select( "id, name, modifiedDate" )
+                                    .selectRaw( "'Document' AS typeName" )
+                                    .from( "document" )
+                                    .orderBy( "modifiedDate", "DESC" )
+                                    .limit( 5 );
+                            } );
+                    } )
+                    .limit( 5 )
+                    .orderBy( "modifiedDate", "DESC" )
+                    .toSql();
+
+                expect( sql ).toBe(
+                    "SELECT TOP (5) * FROM (SELECT * FROM (SELECT TOP (5) [id], [name], [modifiedDate], 'Page' AS typeName FROM [page] ORDER BY [modifiedDate] DESC) AS [qb_union_0] UNION ALL SELECT * FROM (SELECT TOP (5) [id], [name], [modifiedDate], 'Document' AS typeName FROM [document] ORDER BY [modifiedDate] DESC) AS [qb_union_1]) AS [t] ORDER BY [modifiedDate] DESC"
+                );
+            } );
+        } );
     }
 
     function selectAllColumns() {


### PR DESCRIPTION
Closes #201

## What changed

- compile independently ordered and limited SQL Server UNION branches as derived queries
- preserve `TOP` and `ORDER BY` within each branch so each source contributes its intended top rows
- retain the existing compilation and validation behavior for ordinary UNION queries
- add a regression test based on the issue reproduction

## Root cause

qb treated the root `orderBy()` as the final UNION ordering and rejected every `orderBy()` on a unioned builder. SQL Server can support the requested top-N-per-source operation, but each ordered `TOP` query must be isolated as a derived query rather than emitted directly as a UNION operand.

## Validation

- TestBox on Lucee 6: 2,773 passed, 0 failed, 3 skipped
- `box run-script format:check`
- `git diff --check`