### PR TITLE
fix(SchemaBuilder): qualify tables with default schema

### DIFF
--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -608,15 +608,23 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
             return "";
         }
 
-        var table = uCase( blueprint.getTable() );
+        var qualifiedTable = uCase( blueprint.getTable() );
+        var table = listLast( qualifiedTable, "." );
+        var schema = listLen( qualifiedTable, "." ) > 1 ? listDeleteAt(
+            qualifiedTable,
+            listLen( qualifiedTable, "." ),
+            "."
+        ) : "";
         var columnName = uCase( column.getName() );
         var sequenceName = "SEQ_#table#";
         var triggerName = "TRG_#table#";
-        blueprint.addCommand( "raw", { "sql": "CREATE SEQUENCE ""#sequenceName#""" } );
+        var qualifiedSequenceName = schema == "" ? sequenceName : "#schema#.#sequenceName#";
+        var qualifiedTriggerName = schema == "" ? triggerName : "#schema#.#triggerName#";
+        blueprint.addCommand( "raw", { "sql": "CREATE SEQUENCE #wrapTable( qualifiedSequenceName )#" } );
         blueprint.addCommand(
             "raw",
             {
-                "sql": "CREATE OR REPLACE TRIGGER ""#triggerName#"" BEFORE INSERT ON ""#table#"" FOR EACH ROW WHEN (NEW.""#columnName#"" IS NULL) BEGIN SELECT ""#sequenceName#"".NEXTVAL INTO ::NEW.""#columnName#"" FROM dual; END"
+                "sql": "CREATE OR REPLACE TRIGGER #wrapTable( qualifiedTriggerName )# BEFORE INSERT ON #wrapTable( qualifiedTable )# FOR EACH ROW WHEN (NEW.#wrapColumn( { "type": "simple", "value": columnName } )# IS NULL) BEGIN SELECT #wrapTable( qualifiedSequenceName )#.NEXTVAL INTO ::NEW.#wrapColumn( { "type": "simple", "value": columnName } )# FROM dual; END"
             }
         );
         return "";
@@ -837,14 +845,20 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
 
             var statements = [ "DROP TABLE #wrapTable( arguments.blueprint.getTable() )#" ];
 
-            var sequenceName = "SEQ_#uCase( arguments.blueprint.getTable() )#";
+            var table = uCase( listLast( arguments.blueprint.getTable(), "." ) );
+            var schema = listLen( arguments.blueprint.getTable(), "." ) > 1 ? listDeleteAt(
+                arguments.blueprint.getTable(),
+                listLen( arguments.blueprint.getTable(), "." ),
+                "."
+            ) : "";
+            var sequenceName = "SEQ_#table#";
             if ( hasSequence( arguments.blueprint, sequenceName ) ) {
-                statements.append( "DROP SEQUENCE #wrapTable( sequenceName )#" );
+                statements.append( "DROP SEQUENCE #wrapTable( schema == "" ? sequenceName : "#schema#.#sequenceName#" )#" );
             }
 
-            var triggerName = "TRG_#uCase( arguments.blueprint.getTable() )#";
+            var triggerName = "TRG_#table#";
             if ( hasTrigger( arguments.blueprint, triggerName ) ) {
-                statements.append( "DROP TRIGGER #wrapTable( triggerName )#" );
+                statements.append( "DROP TRIGGER #wrapTable( schema == "" ? triggerName : "#schema#.#triggerName#" )#" );
             }
 
             return statements;

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -42,7 +42,7 @@ component accessors="true" {
 
     public Column function bigIncrements( required string name, string indexName ) {
         arguments.autoIncrement = true;
-        param arguments.indexName = "pk_#getTable()#_#name#";
+        param arguments.indexName = "pk_#getUnqualifiedTableName()#_#name#";
         appendIndex( type = "primary", columns = arguments.name, name = arguments.indexName );
         return unsignedBigInteger( argumentCollection = arguments );
     }
@@ -108,7 +108,7 @@ component accessors="true" {
 
     public Column function increments( required string name, string indexName ) {
         arguments.autoIncrement = true;
-        param arguments.indexName = "pk_#getTable()#_#name#";
+        param arguments.indexName = "pk_#getUnqualifiedTableName()#_#name#";
         appendIndex( type = "primary", columns = arguments.name, name = arguments.indexName );
         return unsignedInteger( argumentCollection = arguments );
     }
@@ -140,7 +140,7 @@ component accessors="true" {
 
     public Column function mediumIncrements( required string name, string indexName ) {
         arguments.autoIncrement = true;
-        param arguments.indexName = "pk_#getTable()#_#name#";
+        param arguments.indexName = "pk_#getUnqualifiedTableName()#_#name#";
         appendIndex( type = "primary", columns = arguments.name, name = arguments.indexName );
         return unsignedMediumInteger( argumentCollection = arguments );
     }
@@ -225,7 +225,7 @@ component accessors="true" {
 
     public Column function smallIncrements( required string name, string indexName ) {
         arguments.autoIncrement = true;
-        param arguments.indexName = "pk_#getTable()#_#name#";
+        param arguments.indexName = "pk_#getUnqualifiedTableName()#_#name#";
         appendIndex( type = "primary", columns = arguments.name, name = arguments.indexName );
         return unsignedSmallInteger( argumentCollection = arguments );
     }
@@ -307,7 +307,7 @@ component accessors="true" {
 
     public Column function tinyIncrements( required string name, string indexName ) {
         arguments.autoIncrement = true;
-        param arguments.indexName = "pk_#getTable()#_#name#";
+        param arguments.indexName = "pk_#getUnqualifiedTableName()#_#name#";
         appendIndex( type = "primary", columns = arguments.name, name = arguments.indexName );
         return unsignedTinyInteger( argumentCollection = arguments );
     }
@@ -366,7 +366,7 @@ component accessors="true" {
      */
     public TableIndex function foreignKey( required any columns, string name ) {
         arguments.columns = arrayWrap( arguments.columns );
-        param arguments.name = "fk_#getTable()#_#arrayToList( columns, "_" )#";
+        param arguments.name = "fk_#getUnqualifiedTableName()#_#arrayToList( columns, "_" )#";
         return appendIndex( type = "foreign", foreignKey = arguments.columns, name = arguments.name );
     }
 
@@ -381,7 +381,7 @@ component accessors="true" {
      */
     public TableIndex function index( required any columns, string name ) {
         arguments.columns = arrayWrap( arguments.columns );
-        param arguments.name = "idx_#getTable()#_#arrayToList( columns, "_" )#";
+        param arguments.name = "idx_#getUnqualifiedTableName()#_#arrayToList( columns, "_" )#";
         return appendIndex( type = "basic", columns = arguments.columns, name = arguments.name );
     }
 
@@ -396,7 +396,7 @@ component accessors="true" {
      */
     public TableIndex function primaryKey( required any columns, string name ) {
         arguments.columns = arrayWrap( arguments.columns );
-        param arguments.name = "pk_#getTable()#_#arrayToList( columns, "_" )#";
+        param arguments.name = "pk_#getUnqualifiedTableName()#_#arrayToList( columns, "_" )#";
         return appendIndex( type = "primary", columns = arguments.columns, name = arguments.name );
     }
 
@@ -411,7 +411,7 @@ component accessors="true" {
      */
     public TableIndex function unique( required any columns, string name ) {
         arguments.columns = arrayWrap( arguments.columns );
-        param arguments.name = "unq_#getTable()#_#arrayToList( columns, "_" )#";
+        param arguments.name = "unq_#getUnqualifiedTableName()#_#arrayToList( columns, "_" )#";
         return appendIndex( type = "unique", columns = arguments.columns, name = arguments.name );
     }
 
@@ -425,7 +425,7 @@ component accessors="true" {
      * @returns The created TableIndex instance.
      */
     public TableIndex function default( required string column, string name ) {
-        param arguments.name = "df_#getTable()#_#column#";
+        param arguments.name = "df_#getUnqualifiedTableName()#_#column#";
         return createIndex( type = "default", columns = arguments.column, name = arguments.name );
     }
 
@@ -474,7 +474,7 @@ component accessors="true" {
         }
 
         arguments.columns = arrayWrap( arguments.columns );
-        param arguments.name = "idx_#getTable()#_#arrayToList( columns, "_" )#";
+        param arguments.name = "idx_#getUnqualifiedTableName()#_#arrayToList( columns, "_" )#";
         addCommand(
             "addIndex",
             {
@@ -570,6 +570,10 @@ component accessors="true" {
 
     private array function arrayWrap( required any value ) {
         return isArray( arguments.value ) ? arguments.value : [ arguments.value ];
+    }
+
+    private string function getUnqualifiedTableName() {
+        return listLast( getTable(), "." );
     }
 
     private numeric function clamp( required numeric lowerLimit, required numeric result, required numeric upperLimit ) {

--- a/models/Schema/SchemaBuilder.cfc
+++ b/models/Schema/SchemaBuilder.cfc
@@ -85,7 +85,7 @@ component accessors="true" {
         );
         blueprint.addCommand( "create" );
         blueprint.setCreating( true );
-        blueprint.setTable( arguments.table );
+        blueprint.setTable( qualifyTable( arguments.table ) );
         arguments.callback( blueprint );
         if ( arguments.execute ) {
             blueprint
@@ -124,7 +124,7 @@ component accessors="true" {
         );
         blueprint.addCommand( "createView", { query: query } );
         blueprint.setCreating( true );
-        blueprint.setTable( arguments.view );
+        blueprint.setTable( qualifyTable( arguments.view ) );
 
         if ( arguments.execute ) {
             blueprint
@@ -164,7 +164,7 @@ component accessors="true" {
         );
         blueprint.addCommand( "createAs", { query: query } );
         blueprint.setCreating( true );
-        blueprint.setTable( arguments.newTableName );
+        blueprint.setTable( qualifyTable( arguments.newTableName ) );
 
         if ( arguments.execute ) {
             blueprint
@@ -204,7 +204,7 @@ component accessors="true" {
         );
         blueprint.addCommand( "alterView", { query: query } );
         blueprint.setCreating( true );
-        blueprint.setTable( arguments.view );
+        blueprint.setTable( qualifyTable( arguments.view ) );
 
         if ( arguments.execute ) {
             blueprint
@@ -235,7 +235,7 @@ component accessors="true" {
             getDefaultSchema()
         );
         blueprint.addCommand( "dropView" );
-        blueprint.setTable( arguments.view );
+        blueprint.setTable( qualifyTable( arguments.view ) );
 
         if ( arguments.execute ) {
             blueprint
@@ -275,7 +275,7 @@ component accessors="true" {
             getDefaultSchema()
         );
         blueprint.addCommand( "drop" );
-        blueprint.setTable( arguments.table );
+        blueprint.setTable( qualifyTable( arguments.table ) );
         if ( arguments.execute ) {
             blueprint
                 .toSql()
@@ -313,7 +313,7 @@ component accessors="true" {
             getDefaultSchema()
         );
         blueprint.addCommand( "truncate" );
-        blueprint.setTable( arguments.table );
+        blueprint.setTable( qualifyTable( arguments.table ) );
         if ( arguments.execute ) {
             blueprint
                 .toSql()
@@ -351,7 +351,7 @@ component accessors="true" {
             getDefaultSchema()
         );
         blueprint.addCommand( "drop" );
-        blueprint.setTable( arguments.table );
+        blueprint.setTable( qualifyTable( arguments.table ) );
         blueprint.setIfExists( true );
         if ( arguments.execute ) {
             blueprint
@@ -396,7 +396,7 @@ component accessors="true" {
             arguments.options,
             getDefaultSchema()
         );
-        blueprint.setTable( arguments.table );
+        blueprint.setTable( qualifyTable( arguments.table ) );
         arguments.callback( blueprint );
         if ( arguments.execute ) {
             blueprint
@@ -440,7 +440,7 @@ component accessors="true" {
             arguments.options,
             getDefaultSchema()
         );
-        blueprint.setTable( arguments.from );
+        blueprint.setTable( qualifyTable( arguments.from ) );
         blueprint.addCommand( "renameTable", { to: arguments.to } );
         if ( arguments.execute ) {
             blueprint
@@ -499,6 +499,9 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
+        if ( listLen( arguments.name, "." ) > 1 ) {
+            arguments.schema = listDeleteAt( arguments.name, listLen( arguments.name, "." ), "." );
+        }
         var args = [ listLast( arguments.name, "." ) ];
         if ( arguments.schema != "" ) {
             arrayAppend( args, arguments.schema );
@@ -536,6 +539,9 @@ component accessors="true" {
         boolean execute = true
     ) {
         structAppend( arguments.options, variables.defaultOptions, false );
+        if ( listLen( arguments.table, "." ) > 1 ) {
+            arguments.schema = listDeleteAt( arguments.table, listLen( arguments.table, "." ), "." );
+        }
         var args = [ listLast( arguments.table, "." ), arguments.column ];
         if ( arguments.schema != "" ) {
             arrayAppend( args, arguments.schema );
@@ -656,6 +662,21 @@ component accessors="true" {
             return javacast( "null", "" );
         }
         return variables.shouldWrapValues;
+    }
+
+    /**
+     * Prefixes an unqualified schema object with the configured default schema.
+     * Explicitly qualified object names are returned unchanged.
+     *
+     * @table The table or view name to qualify.
+     *
+     * @return The qualified table or view name.
+     */
+    private string function qualifyTable( required string table ) {
+        if ( variables.defaultSchema == "" || listLen( arguments.table, "." ) > 1 ) {
+            return arguments.table;
+        }
+        return "#variables.defaultSchema#.#arguments.table#";
     }
 
 }

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -4,6 +4,78 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         super.run();
 
         describe( "Oracle Grammar-specific tests", function() {
+            it( "prefixes schema builder tables with the default schema", () => {
+                var schema = getBuilder().setDefaultSchema( "app" );
+                var statements = schema
+                    .create(
+                        "users",
+                        ( table ) => {
+                            table.string( "username" );
+                        },
+                        {},
+                        false
+                    )
+                    .toSql();
+
+                expect( statements ).toBe( [ "CREATE TABLE ""APP"".""USERS"" (""USERNAME"" VARCHAR2(255) NOT NULL)" ] );
+            } );
+
+            it( "preserves explicitly qualified table names", () => {
+                var schema = getBuilder().setDefaultSchema( "app" );
+                var statements = schema
+                    .create(
+                        "audit.users",
+                        ( table ) => {
+                            table.string( "username" );
+                        },
+                        {},
+                        false
+                    )
+                    .toSql();
+
+                expect( statements ).toBe( [ "CREATE TABLE ""AUDIT"".""USERS"" (""USERNAME"" VARCHAR2(255) NOT NULL)" ] );
+            } );
+
+            it( "prefixes generated sequences and triggers without including the schema in their names", () => {
+                var schema = getBuilder().setDefaultSchema( "app" );
+                var statements = schema
+                    .create(
+                        "users",
+                        ( table ) => {
+                            table.increments( "id" );
+                        },
+                        {},
+                        false
+                    )
+                    .toSql();
+
+                expect( statements ).toBe( [
+                    "CREATE TABLE ""APP"".""USERS"" (""ID"" NUMBER(10, 0) NOT NULL, CONSTRAINT ""PK_USERS_ID"" PRIMARY KEY (""ID""))",
+                    "CREATE SEQUENCE ""APP"".""SEQ_USERS""",
+                    "CREATE OR REPLACE TRIGGER ""APP"".""TRG_USERS"" BEFORE INSERT ON ""APP"".""USERS"" FOR EACH ROW WHEN (NEW.""ID"" IS NULL) BEGIN SELECT ""APP"".""SEQ_USERS"".NEXTVAL INTO ::NEW.""ID"" FROM dual; END"
+                ] );
+            } );
+
+            it( "drops generated sequences and triggers from the default schema", () => {
+                var schema = getBuilder().setDefaultSchema( "app" );
+                variables.mockGrammar.$( "hasSequence", true );
+                variables.mockGrammar.$( "hasTrigger", true );
+
+                expect( schema.drop( "users", {}, false ).toSql() ).toBe( [
+                    "DROP TABLE ""APP"".""USERS""",
+                    "DROP SEQUENCE ""APP"".""SEQ_USERS""",
+                    "DROP TRIGGER ""APP"".""TRG_USERS"""
+                ] );
+            } );
+
+            it( "uses an explicit table schema for existence checks", () => {
+                var schema = getBuilder().setDefaultSchema( "app" );
+                variables.mockGrammar.$( "runQuery", queryNew( "" ) );
+                schema.hasTable( "audit.users" );
+
+                expect( variables.mockGrammar.$callLog().runQuery[ 1 ][ 2 ] ).toBe( [ "users", "audit" ] );
+            } );
+
             it( "attempts to drop sequences and triggers when dropping a table", () => {
                 try {
                     var schema = getBuilder();


### PR DESCRIPTION
## Summary

- qualify SchemaBuilder table and view names with `defaultSchema`
- preserve explicitly qualified names and use their schema for existence checks
- keep generated constraint names based on the unqualified table name
- schema-qualify Oracle sequences and triggers without embedding the schema in their generated names
- cover default schemas, explicit schema precedence, Oracle auto-increment objects, drops, and existence checks

## Validation

- tests written first and confirmed failing
- Lucee 6 full suite: 2,922 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format:check`
- `git diff --check`

Fixes #264