### PR TITLE
feat(QueryBuilder): match null upsert targets

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -1024,6 +1024,29 @@ component displayname="Grammar" accessors="true" singleton {
     }
 
     /**
+     * Compiles the target-column comparisons for a MERGE-style upsert.
+     *
+     * @target The columns used to match source and target rows.
+     * @matchNulls Whether two NULL target values should be considered a match.
+     *
+     * @return The compiled match predicate.
+     */
+    public string function compileUpsertTargetConstraint( required array target, boolean matchNulls = false ) {
+        var shouldMatchNulls = arguments.matchNulls;
+        return arguments.target
+            .map( function( column ) {
+                var targetColumn = wrapColumn( { "type": "simple", "value": "qb_target.#column.formatted.value#" } );
+                var sourceColumn = wrapColumn( { "type": "simple", "value": "qb_src.#column.formatted.value#" } );
+                var equality = "#targetColumn# = #sourceColumn#";
+                if ( !shouldMatchNulls ) {
+                    return equality;
+                }
+                return "(#equality# OR (#targetColumn# IS NULL AND #sourceColumn# IS NULL))";
+            } )
+            .toList( " AND " );
+    }
+
+    /**
      * Compile a Builder's query into an insert using string.
      *
      * @query The Builder instance.

--- a/models/Grammars/DerbyGrammar.cfc
+++ b/models/Grammars/DerbyGrammar.cfc
@@ -243,7 +243,8 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
         if ( !isBoolean( arguments.deleteUnmatched ) || arguments.deleteUnmatched ) {
             throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
@@ -287,11 +288,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
                     .toList( ", " );
             }
 
-            var constraintString = arguments.target
-                .map( function( column ) {
-                    return "#wrapColumn( { "type": "simple", "value": "qb_target.#column.formatted.value#" } )# = #wrapColumn( { "type": "simple", "value": "qb_src.#column.formatted.value#" } )#";
-                } )
-                .toList( " AND " );
+            var constraintString = compileUpsertTargetConstraint( arguments.target, arguments.matchNulls );
 
             var updateList = "";
             if ( isArray( arguments.updates ) ) {

--- a/models/Grammars/MySQLGrammar.cfc
+++ b/models/Grammars/MySQLGrammar.cfc
@@ -299,8 +299,15 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
+        if ( arguments.matchNulls ) {
+            throw(
+                type = "UnsupportedOperation",
+                message = "This grammar does not support matching NULL target values during an upsert"
+            );
+        }
         if ( !isBoolean( arguments.deleteUnmatched ) || arguments.deleteUnmatched ) {
             throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
         }

--- a/models/Grammars/OracleGrammar.cfc
+++ b/models/Grammars/OracleGrammar.cfc
@@ -253,7 +253,8 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
         if ( !isBoolean( arguments.deleteUnmatched ) || arguments.deleteUnmatched ) {
             throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
@@ -297,11 +298,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
                     .toList( " UNION ALL " );
             }
 
-            var constraintString = arguments.target
-                .map( function( column ) {
-                    return "#wrapColumn( { "type": "simple", "value": "qb_target.#column.formatted.value#" } )# = #wrapColumn( { "type": "simple", "value": "qb_src.#column.formatted.value#" } )#";
-                } )
-                .toList( " AND " );
+            var constraintString = compileUpsertTargetConstraint( arguments.target, arguments.matchNulls );
 
             var updateList = "";
             if ( isArray( arguments.updates ) ) {

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -262,8 +262,15 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
+        if ( arguments.matchNulls ) {
+            throw(
+                type = "UnsupportedOperation",
+                message = "This grammar does not support matching NULL target values during an upsert"
+            );
+        }
         if ( !isBoolean( arguments.deleteUnmatched ) || arguments.deleteUnmatched ) {
             throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
         }

--- a/models/Grammars/SQLiteGrammar.cfc
+++ b/models/Grammars/SQLiteGrammar.cfc
@@ -277,8 +277,15 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
+        if ( arguments.matchNulls ) {
+            throw(
+                type = "UnsupportedOperation",
+                message = "This grammar does not support matching NULL target values during an upsert"
+            );
+        }
         if ( !isBoolean( arguments.deleteUnmatched ) || arguments.deleteUnmatched ) {
             throw( type = "UnsupportedOperation", message = "This grammar does not support DELETE in a upsert clause" );
         }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -641,7 +641,8 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         required any updates,
         required array target,
         QueryBuilder source,
-        any deleteUnmatched = false
+        any deleteUnmatched = false,
+        boolean matchNulls = false
     ) {
         try {
             var originalShouldWrapValues = getShouldWrapValues();
@@ -676,11 +677,7 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
                 sourceString = "(VALUES #placeholderString#) AS [qb_src] (#columnsString#)";
             }
 
-            var constraintString = arguments.target
-                .map( function( column ) {
-                    return "#wrapColumn( { "type": "simple", "value": "qb_target.#column.formatted.value#" } )# = #wrapColumn( { "type": "simple", "value": "qb_src.#column.formatted.value#" } )#";
-                } )
-                .toList( " AND " );
+            var constraintString = compileUpsertTargetConstraint( arguments.target, arguments.matchNulls );
 
             var updateList = "";
             if ( isArray( arguments.updates ) ) {

--- a/models/Query/QueryBuilder.cfc
+++ b/models/Query/QueryBuilder.cfc
@@ -3978,6 +3978,20 @@ component displayname="QueryBuilder" accessors="true" {
     }
 
 
+    /**
+     * Inserts rows that do not exist and updates rows matching the target columns.
+     *
+     * @values The values to insert or the columns selected by the source query.
+     * @target The columns used to determine whether a row already exists.
+     * @update The columns or explicit values to update when a row matches.
+     * @source An optional query builder or callback used as the source rows.
+     * @deleteUnmatched Whether to delete target rows missing from the source, or a callback constraining those deletes.
+     * @options Options passed to `queryExecute`.
+     * @toSql Whether to return SQL instead of executing the query.
+     * @matchNulls Whether two NULL target values should be considered a match. Supported by MERGE grammars.
+     *
+     * @return The query result, compiled SQL, or nothing when no values are provided.
+     */
     public any function upsert(
         required any values,
         required any target,
@@ -3985,7 +3999,8 @@ component displayname="QueryBuilder" accessors="true" {
         any source,
         any deleteUnmatched = false,
         struct options = {},
-        boolean toSql = false
+        boolean toSql = false,
+        boolean matchNulls = false
     ) {
         if ( arguments.values.isEmpty() ) {
             return;
@@ -4136,7 +4151,8 @@ component displayname="QueryBuilder" accessors="true" {
             arguments.update,
             arguments.target,
             isNull( arguments.source ) ? javacast( "null", "" ) : arguments.source,
-            arguments.deleteUnmatched
+            arguments.deleteUnmatched,
+            arguments.matchNulls
         );
 
         if ( toSql ) {

--- a/tests/resources/AbstractQueryBuilderSpec.cfc
+++ b/tests/resources/AbstractQueryBuilderSpec.cfc
@@ -3081,6 +3081,23 @@ component extends="testbox.system.BaseSpec" {
                     }, upsertSingleTarget() );
                 } );
 
+                it( "can opt in to matching null target values", function() {
+                    testCase( function( builder ) {
+                        return builder
+                            .table( "records" )
+                            .upsert(
+                                values = [
+                                    { "a": 1, "b": javacast( "null", "" ), "c": "first" },
+                                    { "a": 2, "b": "value", "c": "second" }
+                                ],
+                                target = [ "a", "b" ],
+                                update = [ "c" ],
+                                matchNulls = true,
+                                toSql = true
+                            );
+                    }, upsertMatchNulls() );
+                } );
+
                 it( "can perform an upsert with a closure as the source", function() {
                     testCase( function( builder ) {
                         return builder

--- a/tests/specs/Query/DerbyQueryBuilderSpec.cfc
+++ b/tests/specs/Query/DerbyQueryBuilderSpec.cfc
@@ -1029,6 +1029,20 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return {
+            sql: "MERGE INTO ""records"" ""qb_target"" USING (VALUES (?, ?, ?), (?, ?, ?)) AS ""qb_src"" ON (""qb_target"".""a"" = ""qb_src"".""a"" OR (""qb_target"".""a"" IS NULL AND ""qb_src"".""a"" IS NULL)) AND (""qb_target"".""b"" = ""qb_src"".""b"" OR (""qb_target"".""b"" IS NULL AND ""qb_src"".""b"" IS NULL)) WHEN MATCHED THEN UPDATE SET ""c"" = ""qb_src"".""c"" WHEN NOT MATCHED THEN INSERT (""a"", ""b"", ""c"") VALUES (""qb_src"".""a"", ""qb_src"".""b"", ""qb_src"".""c"")",
+            bindings: [
+                1,
+                "NULL",
+                "first",
+                2,
+                "value",
+                "second"
+            ]
+        };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "MERGE INTO ""users"" ""qb_target"" USING (SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ?) AS ""qb_src"" ON ""qb_target"".""username"" = ""qb_src"".""username"" WHEN MATCHED THEN UPDATE SET ""active"" = ""qb_src"".""active"", ""modifiedDate"" = ""qb_src"".""modifiedDate"" WHEN NOT MATCHED THEN INSERT (""username"", ""active"", ""createdDate"", ""modifiedDate"") VALUES (""qb_src"".""username"", ""qb_src"".""active"", ""qb_src"".""createdDate"", ""qb_src"".""modifiedDate"")",

--- a/tests/specs/Query/MySQLQueryBuilderSpec.cfc
+++ b/tests/specs/Query/MySQLQueryBuilderSpec.cfc
@@ -1056,6 +1056,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return { exception: "UnsupportedOperation" };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "INSERT INTO `users` (`username`, `active`, `createdDate`, `modifiedDate`) SELECT `username`, `active`, `createdDate`, `modifiedDate` FROM `activeDirectoryUsers` WHERE `active` = ? ON DUPLICATE KEY UPDATE `active` = VALUES(`active`), `modifiedDate` = VALUES(`modifiedDate`)",

--- a/tests/specs/Query/OracleQueryBuilderSpec.cfc
+++ b/tests/specs/Query/OracleQueryBuilderSpec.cfc
@@ -1075,6 +1075,20 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return {
+            sql: "MERGE INTO ""RECORDS"" ""QB_TARGET"" USING (SELECT ?, ?, ? FROM dual UNION ALL SELECT ?, ?, ? FROM dual) ""QB_SRC"" ON (""QB_TARGET"".""A"" = ""QB_SRC"".""A"" OR (""QB_TARGET"".""A"" IS NULL AND ""QB_SRC"".""A"" IS NULL)) AND (""QB_TARGET"".""B"" = ""QB_SRC"".""B"" OR (""QB_TARGET"".""B"" IS NULL AND ""QB_SRC"".""B"" IS NULL)) WHEN MATCHED THEN UPDATE SET ""C"" = ""QB_SRC"".""C"" WHEN NOT MATCHED THEN INSERT (""A"", ""B"", ""C"") VALUES (""QB_SRC"".""A"", ""QB_SRC"".""B"", ""QB_SRC"".""C"")",
+            bindings: [
+                1,
+                "NULL",
+                "first",
+                2,
+                "value",
+                "second"
+            ]
+        };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "MERGE INTO ""USERS"" ""QB_TARGET"" USING (SELECT ""USERNAME"", ""ACTIVE"", ""CREATEDDATE"", ""MODIFIEDDATE"" FROM ""ACTIVEDIRECTORYUSERS"" WHERE ""ACTIVE"" = ?) ""QB_SRC"" ON ""QB_TARGET"".""USERNAME"" = ""QB_SRC"".""USERNAME"" WHEN MATCHED THEN UPDATE SET ""ACTIVE"" = ""QB_SRC"".""ACTIVE"", ""MODIFIEDDATE"" = ""QB_SRC"".""MODIFIEDDATE"" WHEN NOT MATCHED THEN INSERT (""USERNAME"", ""ACTIVE"", ""CREATEDDATE"", ""MODIFIEDDATE"") VALUES (""QB_SRC"".""USERNAME"", ""QB_SRC"".""ACTIVE"", ""QB_SRC"".""CREATEDDATE"", ""QB_SRC"".""MODIFIEDDATE"")",

--- a/tests/specs/Query/PostgresQueryBuilderSpec.cfc
+++ b/tests/specs/Query/PostgresQueryBuilderSpec.cfc
@@ -1089,6 +1089,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return { exception: "UnsupportedOperation" };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",

--- a/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SQLiteQueryBuilderSpec.cfc
@@ -1185,6 +1185,10 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return { exception: "UnsupportedOperation" };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "INSERT INTO ""users"" (""username"", ""active"", ""createdDate"", ""modifiedDate"") SELECT ""username"", ""active"", ""createdDate"", ""modifiedDate"" FROM ""activeDirectoryUsers"" WHERE ""active"" = ? ON CONFLICT (""username"") DO UPDATE SET ""active"" = EXCLUDED.""active"", ""modifiedDate"" = EXCLUDED.""modifiedDate""",

--- a/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
+++ b/tests/specs/Query/SqlServerQueryBuilderSpec.cfc
@@ -1148,6 +1148,20 @@ component extends="tests.resources.AbstractQueryBuilderSpec" {
         };
     }
 
+    function upsertMatchNulls() {
+        return {
+            sql: "MERGE [records] AS [qb_target] USING (VALUES (?, ?, ?), (?, ?, ?)) AS [qb_src] ([a], [b], [c]) ON ([qb_target].[a] = [qb_src].[a] OR ([qb_target].[a] IS NULL AND [qb_src].[a] IS NULL)) AND ([qb_target].[b] = [qb_src].[b] OR ([qb_target].[b] IS NULL AND [qb_src].[b] IS NULL)) WHEN MATCHED THEN UPDATE SET [c] = [qb_src].[c] WHEN NOT MATCHED BY TARGET THEN INSERT ([a], [b], [c]) VALUES ([a], [b], [c]);",
+            bindings: [
+                1,
+                "NULL",
+                "first",
+                2,
+                "value",
+                "second"
+            ]
+        };
+    }
+
     function upsertFromClosure() {
         return {
             sql: "MERGE [users] AS [qb_target] USING (SELECT [username], [active], [createdDate], [modifiedDate] FROM [activeDirectoryUsers] WHERE [active] = ?) AS [qb_src] ON [qb_target].[username] = [qb_src].[username] WHEN MATCHED THEN UPDATE SET [active] = [qb_src].[active], [modifiedDate] = [qb_src].[modifiedDate] WHEN NOT MATCHED BY TARGET THEN INSERT ([username], [active], [createdDate], [modifiedDate]) VALUES ([username], [active], [createdDate], [modifiedDate]);",


### PR DESCRIPTION
## Summary

- add an opt-in `matchNulls` argument to `upsert`
- generate null-safe target predicates for SQL Server, Oracle, and Derby `MERGE` statements
- preserve existing equality predicates when the option is disabled
- reject the option on MySQL, PostgreSQL, and SQLite, where conflict matching is controlled by unique-index semantics
- cover mixed null and non-null source rows across every grammar

## Example

```cfml
qb.table( "records" ).upsert(
    values = rows,
    target = [ "a", "b" ],
    update = [ "c" ],
    matchNulls = true
);
```

## Validation

- tests written first and confirmed failing across all six grammars
- Lucee 6 full suite: 2,778 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format:check`
- `git diff --check`

Fixes #272