### PR TITLE
feat(schema): add binary() column type to the schema builder

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -2078,6 +2078,10 @@ component displayname="Grammar" accessors="true" singleton {
         return concatenate( [ "BIGINT", isNull( column.getPrecision() ) ? "" : "(#column.getPrecision()#)" ], "" );
     }
 
+    function typeBinary( column ) {
+        return "BLOB";
+    }
+
     function typeBit( column ) {
         return "BIT(#column.getLength()#)";
     }

--- a/models/Grammars/PostgresGrammar.cfc
+++ b/models/Grammars/PostgresGrammar.cfc
@@ -716,6 +716,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton {
     =           Column Types            =
     ===================================*/
 
+    function typeBinary( column ) {
+        return "BYTEA";
+    }
+
     function typeBoolean( column ) {
         return "BOOLEAN";
     }

--- a/models/Grammars/SqlServerGrammar.cfc
+++ b/models/Grammars/SqlServerGrammar.cfc
@@ -1230,6 +1230,10 @@ component extends="qb.models.Grammars.BaseGrammar" singleton accessors="true" {
         return "BIGINT";
     }
 
+    function typeBinary( column ) {
+        return "VARBINARY(MAX)";
+    }
+
     function typeBit( column ) {
         return "BIT";
     }

--- a/models/Schema/Blueprint.cfc
+++ b/models/Schema/Blueprint.cfc
@@ -52,6 +52,11 @@ component accessors="true" {
         return appendColumn( argumentCollection = arguments );
     }
 
+    public Column function binary( required string name ) {
+        arguments.type = "binary";
+        return appendColumn( argumentCollection = arguments );
+    }
+
     public Column function bit( required string name, numeric length = 1 ) {
         arguments.type = "bit";
         return appendColumn( argumentCollection = arguments );

--- a/tests/resources/AbstractSchemaBuilderSpec.cfc
+++ b/tests/resources/AbstractSchemaBuilderSpec.cfc
@@ -92,6 +92,19 @@ component extends="testbox.system.BaseSpec" {
                     }, bigIntegerWithPrecision() );
                 } );
 
+                it( "binary", function() {
+                    testCase( function( schema ) {
+                        return schema.create(
+                            "users",
+                            function( table ) {
+                                table.binary( "avatar" );
+                            },
+                            {},
+                            false
+                        );
+                    }, binary() );
+                } );
+
                 it( "bit", function() {
                     testCase( function( schema ) {
                         return schema.create(

--- a/tests/specs/Schema/DerbySchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/DerbySchemaBuilderSpec.cfc
@@ -49,6 +49,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""weather_reports"" (""temperature"" BIGINT NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE ""users"" (""avatar"" BLOB NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE ""users"" (""active"" CHAR(1) NOT NULL)" ];
     }

--- a/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/MySQLSchemaBuilderSpec.cfc
@@ -65,6 +65,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE `weather_reports` (`temperature` BIGINT(5) NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE `users` (`avatar` BLOB NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE `users` (`active` BIT(1) NOT NULL)" ];
     }

--- a/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/OracleSchemaBuilderSpec.cfc
@@ -159,6 +159,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""WEATHER_REPORTS"" (""TEMPERATURE"" NUMBER(5, 0) NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE ""USERS"" (""AVATAR"" BLOB NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE ""USERS"" (""ACTIVE"" RAW NOT NULL)" ];
     }

--- a/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/PostgresSchemaBuilderSpec.cfc
@@ -91,6 +91,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""weather_reports"" (""temperature"" NUMERIC(5) NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE ""users"" (""avatar"" BYTEA NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE ""users"" (""active"" BIT(1) NOT NULL)" ];
     }

--- a/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SQLiteSchemaBuilderSpec.cfc
@@ -121,6 +121,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE ""weather_reports"" (""temperature"" BIGINT NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE ""users"" (""avatar"" BLOB NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE ""users"" (""active"" BOOLEAN NOT NULL)" ];
     }

--- a/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
+++ b/tests/specs/Schema/SqlServerSchemaBuilderSpec.cfc
@@ -178,6 +178,10 @@ component extends="tests.resources.AbstractSchemaBuilderSpec" {
         return [ "CREATE TABLE [weather_reports] ([temperature] NUMERIC(5) NOT NULL)" ];
     }
 
+    function binary() {
+        return [ "CREATE TABLE [users] ([avatar] VARBINARY(MAX) NOT NULL)" ];
+    }
+
     function bit() {
         return [ "CREATE TABLE [users] ([active] BIT NOT NULL)" ];
     }


### PR DESCRIPTION
Adds a grammar-agnostic Blueprint.binary() method so BLOB/binary
columns no longer require a raw() expression. Maps to BLOB by
default, with BYTEA on Postgres and VARBINARY(MAX) on SQL Server.
